### PR TITLE
Fix Docker build and ActivityKit type error

### DIFF
--- a/Apps/FlowKitController/App/AppState.swift
+++ b/Apps/FlowKitController/App/AppState.swift
@@ -125,7 +125,7 @@ final class AppState {
                 } else {
                     activity = try Activity<WindowAttributes>.request(
                         attributes: WindowAttributes(),
-                        content: activityViewState,
+                        content: .init(state: activityViewState, staleDate: nil),
                         pushType: .token
                     )
                 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:6.2-noble AS build
+FROM swift:6.0-noble AS build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
## Summary
- Fix Docker build failure by using `swift:6.0-noble` instead of non-existent `swift:6.2-noble`
- Fix ActivityKit type conversion error in AppState.swift by wrapping `activityViewState` in `ActivityContent` initializer

## Test plan
- [ ] Docker image builds successfully on GitHub Actions
- [ ] FlowKit Controller compiles without type errors
- [ ] Live activity functionality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)