### PR TITLE
Improve Live Activity layout with fixed progress width

### DIFF
--- a/Apps/FlowKitController/Shared/WindowOpenLiveActivityView.swift
+++ b/Apps/FlowKitController/Shared/WindowOpenLiveActivityView.swift
@@ -14,13 +14,20 @@ struct WindowOpenLiveActivityView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             ForEach(contentState.windowStates, id: \.hashValue) { windowState in
-                HStack(spacing: 12) {
-                    ProgressView(timerInterval: windowState.opened...windowState.end, countsDown: false)
-                        .tint(Date() <= windowState.end ? Color.accentColor : Color.red)
+                GeometryReader { geometry in
+                    HStack(spacing: 12) {
+                        ProgressView(timerInterval: windowState.opened...windowState.end, countsDown: false)
+                            .tint(Date() <= windowState.end ? Color.accentColor : Color.red)
+                            .frame(width: geometry.size.width / 3 - 6)
 
-                    Text(windowState.name)
-                        .font(.body)
+                        Text(windowState.name)
+                            .font(.body)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .frame(width: geometry.size.width * 2 / 3 - 6, alignment: .leading)
+                    }
                 }
+                .frame(height: 20)
             }
         }
         .padding()


### PR DESCRIPTION
## Summary
Optimize the Live Activity expanded view layout for better readability:
- Progress bar takes exactly 1/3 of available width
- Window name is displayed in a single line with truncation
- Consistent height for all rows

## Changes
- Use `GeometryReader` for proportional width distribution (1:2 ratio)
- Add `lineLimit(1)` and `truncationMode(.tail)` to window name
- Set fixed height of 20pt for each row
- Progress: `width = geometry.size.width / 3 - 6`
- Text: `width = geometry.size.width * 2 / 3 - 6`

## Visual Improvements
- More predictable and consistent layout
- Long window names no longer cause layout issues
- Progress bar has consistent size across all windows
- Better space utilization

## Test Plan
- [ ] Build and run on device with Live Activities enabled
- [ ] Open multiple windows with varying name lengths
- [ ] Verify progress bar is consistently 1/3 width
- [ ] Verify text truncates properly for long names
- [ ] Check layout in both compact and expanded views