### PR TITLE
Make APNS optional in DEBUG builds

### DIFF
--- a/Sources/Server/Controllers/PushNotifcationService.swift
+++ b/Sources/Server/Controllers/PushNotifcationService.swift
@@ -15,10 +15,10 @@ actor PushNotifcationService: NotificationSender {
     private static let logger = Logger(label: "PushNotifcationService")
 
     let database: any Database
-    let apnsClient: APNSGenericClient
+    let apnsClient: any APNSClientProtocol & Sendable
     let notificationTopic: String
 
-    init(database: any Database, apnsClient: APNSGenericClient, notificationTopic: String) {
+    init(database: any Database, apnsClient: any APNSClientProtocol & Sendable, notificationTopic: String) {
         self.database = database
         self.apnsClient = apnsClient
         self.notificationTopic = notificationTopic

--- a/Sources/Server/configure.swift
+++ b/Sources/Server/configure.swift
@@ -1,6 +1,6 @@
 import Adapter
 import APNS
-import APNSCore
+@preconcurrency import APNSCore
 import APNSURLSession
 import CoreFoundation
 import FluentMySQLDriver
@@ -30,10 +30,25 @@ public func configure(_ app: Application) async throws {
 
     // MARK: - env parsing
 
-    let notificationTopic = Environment.get("PUSH_NOTIFICATION_TOPIC") ?? "de.juliankahnert.HomeAutomation"
-    let notificationPrivateKey = String.fromBase64(Environment.get("PUSH_NOTIFICATION_PRIVATE_KEY_BASE64")!)!
-    let notificationKeyIdentifier = Environment.get("PUSH_NOTIFICATION_KEY_IDENTIFIER")!
-    let notificationTeamIdentifier = Environment.get("PUSH_NOTIFICATION_TEAM_IDENTIFIER")!
+    #if DEBUG
+    // Mock APNS Client for DEBUG builds
+    final class MockAPNSClient: APNSClientProtocol, Sendable {
+        private let logger: Logger
+
+        init(logger: Logger) {
+            self.logger = logger
+        }
+
+        func send(_ request: APNSRequest<some APNSMessage>) async throws -> APNSResponse {
+            logger.debug("📱 [MOCK APNS] Would send notification to device token")
+            return APNSResponse(apnsID: UUID(), apnsUniqueID: nil)
+        }
+
+        func shutdown() async throws {
+            logger.debug("🔕 [MOCK APNS] Shutdown called")
+        }
+    }
+    #endif
 
     // MARK: - database setup
 
@@ -55,9 +70,59 @@ public func configure(_ app: Application) async throws {
 
     // MARK: - configure APNS
 
-    // Configure APNS using JWT authentication.
+    #if DEBUG
+    // Check if real APNS is requested in DEBUG builds
+    let useRealAPNS = Environment.get("ENABLE_APNS_DEBUG") == "true"
+
+    let apnsClient: any APNSClientProtocol & Sendable
+    let notificationTopic: String
+
+    if useRealAPNS {
+        app.logger.info("✅ Real APNS enabled in DEBUG via ENABLE_APNS_DEBUG=true")
+
+        // Real APNS configuration (same as release)
+        notificationTopic = Environment.get("PUSH_NOTIFICATION_TOPIC") ?? "de.juliankahnert.HomeAutomation"
+        let notificationPrivateKey = String.fromBase64(Environment.get("PUSH_NOTIFICATION_PRIVATE_KEY_BASE64")!)!
+        let notificationKeyIdentifier = Environment.get("PUSH_NOTIFICATION_KEY_IDENTIFIER")!
+        let notificationTeamIdentifier = Environment.get("PUSH_NOTIFICATION_TEAM_IDENTIFIER")!
+
+        let apnsEnvironment: APNSEnvironment = app.environment == .production ? .production : .development
+        app.logger.info("Using apns url \(apnsEnvironment.absoluteURL)")
+
+        let apnsConfig = APNSClientConfiguration(
+            authenticationMethod: .jwt(
+                privateKey: try .loadFrom(string: notificationPrivateKey),
+                keyIdentifier: notificationKeyIdentifier,
+                teamIdentifier: notificationTeamIdentifier
+            ),
+            environment: apnsEnvironment
+        )
+
+        await app.apns.containers.use(
+            apnsConfig,
+            eventLoopGroupProvider: .shared(app.eventLoopGroup),
+            responseDecoder: JSONDecoder(),
+            requestEncoder: JSONEncoder(),
+            as: .default
+        )
+
+        apnsClient = await app.apns.client
+    } else {
+        app.logger.info("🔕 APNS disabled in DEBUG - using mock client (set ENABLE_APNS_DEBUG=true to enable)")
+        apnsClient = MockAPNSClient(logger: app.logger)
+        notificationTopic = "mock.topic"
+    }
+
+    #else
+    // RELEASE: Always use real APNS
+    let notificationTopic = Environment.get("PUSH_NOTIFICATION_TOPIC") ?? "de.juliankahnert.HomeAutomation"
+    let notificationPrivateKey = String.fromBase64(Environment.get("PUSH_NOTIFICATION_PRIVATE_KEY_BASE64")!)!
+    let notificationKeyIdentifier = Environment.get("PUSH_NOTIFICATION_KEY_IDENTIFIER")!
+    let notificationTeamIdentifier = Environment.get("PUSH_NOTIFICATION_TEAM_IDENTIFIER")!
+
     let apnsEnvironment: APNSEnvironment = app.environment == .production ? .production : .development
     app.logger.info("Using apns url \(apnsEnvironment.absoluteURL)")
+
     let apnsConfig = APNSClientConfiguration(
         authenticationMethod: .jwt(
             privateKey: try .loadFrom(string: notificationPrivateKey),
@@ -75,6 +140,9 @@ public func configure(_ app: Application) async throws {
         as: .default
     )
 
+    let apnsClient = await app.apns.client
+    #endif
+
     // MARK: - actor system setup
 
     let actorSystem = await CustomActorSystem(nodeId: .server, port: 8888)
@@ -88,7 +156,7 @@ public func configure(_ app: Application) async throws {
 
     app.homeAutomationConfigService = HomeAutomationConfigService.loadOrDefault()
     let notificationSender = await PushNotifcationService(database: app.db,
-                                                          apnsClient: app.apns.client,
+                                                          apnsClient: apnsClient,
                                                           notificationTopic: notificationTopic)
 
     let homeManager = await HomeManager(getAdapter: {


### PR DESCRIPTION
## Summary
- APNS is now disabled by default in DEBUG builds, using a mock client that logs notifications
- No APNS credentials required for local development in DEBUG mode
- Can be optionally enabled in DEBUG builds via `ENABLE_APNS_DEBUG=true` environment variable
- RELEASE builds unchanged (APNS always enabled)

## Changes
- Added `MockAPNSClient` that implements `APNSClientProtocol` and logs all notification calls
- Implemented conditional compilation (`#if DEBUG`) to choose between mock and real APNS client
- Changed `PushNotificationService` to use `APNSClientProtocol & Sendable` instead of concrete `APNSGenericClient` type to support dependency injection
- Added `@preconcurrency import APNSCore` to handle concurrency checks

## Testing
- ✅ Builds successfully in DEBUG configuration (verified with `swift build -c debug`)
- ✅ RELEASE build remains unchanged

## Usage in DEBUG
**Default (no APNS credentials needed):**
```bash
swift run
# Logs: 🔕 APNS disabled in DEBUG - using mock client
```

**With real APNS (for testing):**
```bash
ENABLE_APNS_DEBUG=true swift run
# Requires APNS credentials
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)