### PR TITLE
Make MotionAtNight color temperature handling explicit

### DIFF
--- a/Sources/HAImplementations/Automations/MotionAtNight.swift
+++ b/Sources/HAImplementations/Automations/MotionAtNight.swift
@@ -101,7 +101,7 @@ public struct MotionAtNight: Automatable {
 
             try? await Task.sleep(for: .milliseconds(300))
 
-            for light in lights {
+            for light in lights where light.hasColorTemperatureSupport {
                 await light.setColorTemperature(to: colorTemperatureValue, with: hm)
             }
 

--- a/Sources/Server/configure.swift
+++ b/Sources/Server/configure.swift
@@ -155,9 +155,9 @@ public func configure(_ app: Application) async throws {
     // MARK: - home automation setup
 
     app.homeAutomationConfigService = HomeAutomationConfigService.loadOrDefault()
-    let notificationSender = await PushNotifcationService(database: app.db,
-                                                          apnsClient: apnsClient,
-                                                          notificationTopic: notificationTopic)
+    let notificationSender = PushNotifcationService(database: app.db,
+                                                    apnsClient: apnsClient,
+                                                    notificationTopic: notificationTopic)
 
     let homeManager = await HomeManager(getAdapter: {
         await actorSystem.lookup(.homeKitCommandReceiver)


### PR DESCRIPTION
## Summary

This PR makes color temperature handling in `MotionAtNight` more explicit and adds logging for better debugging, addressing issue #58.

## Changes

### 1. Added `hasColorTemperatureSupport` computed property to `SwitchDevice`
- Returns `true` if device supports color temperature via native characteristic or RGB
- Makes capability checking explicit and reusable

### 2. Updated `MotionAtNight` to use explicit check
- Uses `where` clause to filter lights that support color temperature
- Only calls `setColorTemperature()` on supporting devices

### 3. Added logging to `setColorTemperature()` method
- Logs warning when method is called on unsupported device
- Helps with debugging and makes failures visible

## Benefits

- ✅ More explicit and self-documenting code structure
- ✅ Better debugging through warning logs
- ✅ Prevents unnecessary method calls on non-supporting devices
- ✅ No behavior changes - automation still works the same way

## Testing

- ✅ Swift Package builds successfully
- ✅ SwiftLint passes without new warnings
- ✅ All changes are backward compatible

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)