### PR TITLE
Filter self from discovery nodes to prevent connection hangs

### DIFF
--- a/Sources/Adapter/DistributedActors/CustomActorSystem.swift
+++ b/Sources/Adapter/DistributedActors/CustomActorSystem.swift
@@ -21,10 +21,13 @@ public final class CustomActorSystem: Sendable {
     private let actorSystem: ClusterSystem
 
     public init(nodeId: NodeIdentity, host: String = "0.0.0.0", port: Int) async {
-        let nodes = Set<Cluster.Endpoint>([
+        let allNodes = Set<Cluster.Endpoint>([
             .init(host: "0.0.0.0", port: 7777),
             .init(host: "0.0.0.0", port: 8888)
         ])
+
+        // Remove "self" to prevent hangs in initial connection between adapter and server
+        let nodes = allNodes.filter { $0.port != port }
 
         // setup cluster
         var settings = ClusterSystemSettings(name: nodeId.id, host: host, port: port)


### PR DESCRIPTION
## Summary
- Filter out nodes matching the current port during CustomActorSystem initialization
- Prevents the system from attempting to connect to itself
- Fixes potential hangs during initial connection between adapter and server

## Changes
- Modified `CustomActorSystem.init()` in `Sources/Adapter/DistributedActors/CustomActorSystem.swift`
- Added filtering logic to remove nodes with matching port before configuring service discovery
- Added inline comment explaining the purpose

## Testing
- ✅ SwiftLint passes
- ✅ Swift package builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)