### PR TITLE
Implement automatic view refresh on scene phase change

### DIFF
--- a/Sources/Controller/Shared/ViewModifiers/OnSceneChangeModifier.swift
+++ b/Sources/Controller/Shared/ViewModifiers/OnSceneChangeModifier.swift
@@ -1,0 +1,52 @@
+//
+//  OnSceneChangeModifier.swift
+//  ControllerFeatures
+//
+//  Custom view modifier that observes scene phase changes
+//  and triggers actions when the scene phase transitions occur
+//
+
+import SwiftUI
+
+/// View modifier that observes scene phase changes and executes an action
+/// whenever the scene phase changes.
+///
+/// This modifier provides both the old and new ScenePhase values to the action
+/// closure, allowing the caller to decide which transitions are relevant.
+struct OnSceneChangeModifier: ViewModifier {
+    @Environment(\.scenePhase) private var scenePhase
+
+    let action: (ScenePhase, ScenePhase) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: scenePhase) { oldPhase, newPhase in
+                action(oldPhase, newPhase)
+            }
+    }
+}
+
+extension View {
+    /// Performs an action when the app's scene phase changes.
+    ///
+    /// This modifier is useful for responding to scene phase transitions,
+    /// such as when the app becomes active from inactive or background states.
+    /// The action receives both the old and new scene phases to allow fine-grained
+    /// control over which transitions trigger specific behavior.
+    ///
+    /// - Parameter action: The action to perform when scene phase changes.
+    ///                     Receives the old and new scene phases as parameters.
+    ///
+    /// # Example
+    /// ```swift
+    /// ContentView()
+    ///     .onSceneChange { oldPhase, newPhase in
+    ///         if newPhase == .active {
+    ///             store.send(.scenePhaseChanged(old: oldPhase, new: newPhase))
+    ///         }
+    ///     }
+    /// ```
+    func onSceneChange(perform action: @escaping (ScenePhase, ScenePhase) -> Void) -> some View {
+        modifier(OnSceneChangeModifier(action: action))
+    }
+}

--- a/Tests/ControllerTests/AppFeatureTests.swift
+++ b/Tests/ControllerTests/AppFeatureTests.swift
@@ -1,0 +1,305 @@
+//
+//  AppFeatureTests.swift
+//  ControllerFeaturesTests
+//
+//  Tests for AppFeature scene phase change handling
+//
+
+import ComposableArchitecture
+@testable import Controller
+import Dependencies
+import HAModels
+import Testing
+
+@Suite("AppFeature Tests")
+struct AppFeatureTests {
+
+    @Test("scenePhaseChanged from inactive to active dispatches refresh to all child features")
+    @MainActor
+    func testScenePhaseChangedInactiveToActive() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .testValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        // Send the scene change action for inactive -> active transition
+        await store.send(.scenePhaseChanged(old: .inactive, new: .active))
+
+        // Verify that refresh actions are dispatched to all child features
+        await store.receive(\.automations.refresh) { state in
+            state.automations.isLoading = true
+            state.automations.error = nil
+        }
+
+        await store.receive(\.actions.refresh) { state in
+            state.actions.isLoading = true
+            state.actions.alert = nil
+        }
+
+        await store.receive(\.refreshWindowStates)
+
+        await store.receive(\.startMonitoringLiveActivities)
+
+        await store.receive(\.settings.refreshWindowStates) { state in
+            state.settings.isLoadingWindowStates = true
+            state.settings.error = nil
+        }
+
+        // Verify that the refresh operations complete
+        await store.receive(\.automations.automationsResponse) { state in
+            state.automations.isLoading = false
+        }
+
+        await store.receive(\.actions.actionsResponse) { state in
+            state.actions.isLoading = false
+        }
+
+        await store.receive(\.settings.windowStatesResponse) { state in
+            state.settings.isLoadingWindowStates = false
+            state.settings.windowContentState = WindowContentState(windowStates: [])
+        }
+    }
+
+    @Test("scenePhaseChanged from background to active dispatches refresh to all child features")
+    @MainActor
+    func testScenePhaseChangedBackgroundToActive() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .testValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        // Send the scene change action for background -> active transition
+        await store.send(.scenePhaseChanged(old: .background, new: .active))
+
+        // Verify that refresh actions are dispatched to all child features
+        await store.receive(\.automations.refresh) { state in
+            state.automations.isLoading = true
+            state.automations.error = nil
+        }
+
+        await store.receive(\.actions.refresh) { state in
+            state.actions.isLoading = true
+            state.actions.alert = nil
+        }
+
+        await store.receive(\.refreshWindowStates)
+
+        await store.receive(\.startMonitoringLiveActivities)
+
+        await store.receive(\.settings.refreshWindowStates) { state in
+            state.settings.isLoadingWindowStates = true
+            state.settings.error = nil
+        }
+
+        // Verify that the refresh operations complete
+        await store.receive(\.automations.automationsResponse) { state in
+            state.automations.isLoading = false
+        }
+
+        await store.receive(\.actions.actionsResponse) { state in
+            state.actions.isLoading = false
+        }
+
+        await store.receive(\.settings.windowStatesResponse) { state in
+            state.settings.isLoadingWindowStates = false
+            state.settings.windowContentState = WindowContentState(windowStates: [])
+        }
+    }
+
+    @Test("scenePhaseChanged refreshes run in parallel")
+    @MainActor
+    func testParallelRefresh() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .testValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        // Send the scene change action
+        await store.send(.scenePhaseChanged(old: .background, new: .active))
+
+        // All refresh actions should be dispatched
+        // The order may vary due to parallel execution, but all should arrive
+        await store.receive(\.automations.refresh) { state in
+            state.automations.isLoading = true
+            state.automations.error = nil
+        }
+
+        await store.receive(\.actions.refresh) { state in
+            state.actions.isLoading = true
+            state.actions.alert = nil
+        }
+
+        await store.receive(\.refreshWindowStates)
+
+        await store.receive(\.startMonitoringLiveActivities)
+
+        await store.receive(\.settings.refreshWindowStates) { state in
+            state.settings.isLoadingWindowStates = true
+            state.settings.error = nil
+        }
+
+        // Complete all operations
+        await store.receive(\.automations.automationsResponse) { state in
+            state.automations.isLoading = false
+        }
+
+        await store.receive(\.actions.actionsResponse) { state in
+            state.actions.isLoading = false
+        }
+
+        await store.receive(\.settings.windowStatesResponse) { state in
+            state.settings.isLoadingWindowStates = false
+            state.settings.windowContentState = WindowContentState(windowStates: [])
+        }
+    }
+
+    @Test("scenePhaseChanged with mock data refreshes successfully")
+    @MainActor
+    func testScenePhaseChangedWithMockData() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .previewValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        // Disable exhaustive testing to avoid issues with exact date matching in WindowState
+        store.exhaustivity = .off
+
+        await store.send(.scenePhaseChanged(old: .inactive, new: .active))
+
+        // Wait for all actions to complete
+        await store.receive(\.automations.refresh)
+        await store.receive(\.actions.refresh)
+        await store.receive(\.refreshWindowStates)
+        await store.receive(\.startMonitoringLiveActivities)
+        await store.receive(\.settings.refreshWindowStates)
+        await store.receive(\.automations.automationsResponse)
+        await store.receive(\.actions.actionsResponse)
+        await store.receive(\.settings.windowStatesResponse)
+
+        // Verify the final state
+        let finalState = store.state
+        #expect(finalState.automations.automations.count == 3)
+        #expect(finalState.actions.actions.count == 1)
+        #expect(finalState.settings.windowContentState?.windowStates.count == 1)
+        #expect(finalState.settings.windowContentState?.windowStates.first?.name == "Living Room Window")
+    }
+
+    @Test("scenePhaseChanged ignores non-active transitions")
+    @MainActor
+    func testScenePhaseChangedIgnoresNonActiveTransitions() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .testValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        // Send the scene change action for active -> background transition
+        // This should not trigger any refresh actions
+        await store.send(.scenePhaseChanged(old: .active, new: .background))
+
+        // No refresh actions should be dispatched
+    }
+
+    @Test("scenePhaseChanged ignores active to inactive transition")
+    @MainActor
+    func testScenePhaseChangedIgnoresActiveToInactive() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .testValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        // Send the scene change action for active -> inactive transition
+        // This should not trigger any refresh actions
+        await store.send(.scenePhaseChanged(old: .active, new: .inactive))
+
+        // No refresh actions should be dispatched
+    }
+
+    @Test("scenePhaseChanged triggers monitoring on app launch")
+    @MainActor
+    func testScenePhaseChangedTriggersMonitoring() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .testValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        // Initial app launch triggers monitoring
+        await store.send(.scenePhaseChanged(old: .inactive, new: .active))
+
+        await store.receive(\.automations.refresh) { state in
+            state.automations.isLoading = true
+            state.automations.error = nil
+        }
+
+        await store.receive(\.actions.refresh) { state in
+            state.actions.isLoading = true
+            state.actions.alert = nil
+        }
+
+        await store.receive(\.refreshWindowStates)
+
+        await store.receive(\.startMonitoringLiveActivities)
+
+        await store.receive(\.settings.refreshWindowStates) { state in
+            state.settings.isLoadingWindowStates = true
+            state.settings.error = nil
+        }
+
+        await store.receive(\.automations.automationsResponse) { state in
+            state.automations.isLoading = false
+        }
+
+        await store.receive(\.actions.actionsResponse) { state in
+            state.actions.isLoading = false
+        }
+
+        await store.receive(\.settings.windowStatesResponse) { state in
+            state.settings.isLoadingWindowStates = false
+            state.settings.windowContentState = WindowContentState(windowStates: [])
+        }
+    }
+
+    @Test("refreshWindowStates delegates to settings feature")
+    @MainActor
+    func testRefreshWindowStates() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.serverClient = .testValue
+            $0.liveActivity = .testValue
+            $0.pushNotification = .testValue
+        }
+
+        await store.send(.refreshWindowStates)
+
+        await store.receive(\.settings.refreshWindowStates) { state in
+            state.settings.isLoadingWindowStates = true
+            state.settings.error = nil
+        }
+
+        await store.receive(\.settings.windowStatesResponse) { state in
+            state.settings.isLoadingWindowStates = false
+            state.settings.windowContentState = WindowContentState(windowStates: [])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements centralized automatic view refresh when the FlowKit Controller app launches or returns to foreground, addressing issue #68.

The UI automatically refreshes to show the latest data from the server across all tabs on both:
- **Initial app launch** (inactive → active)
- **Return from background** (background → active)

This eliminates the need for individual `onAppear` handlers in tab views, centralizing all initialization logic in AppFeature.

## Implementation

### Files Created

1. **`Sources/Controller/Shared/ViewModifiers/OnSceneChangeModifier.swift`**
   - Custom SwiftUI ViewModifier that observes `@Environment(\.scenePhase)`
   - Provides both old and new ScenePhase values to closure
   - Triggers on all scene phase transitions for maximum flexibility

2. **`Tests/ControllerTests/AppFeatureTests.swift`**
   - Comprehensive unit tests for AppFeature scene change handling
   - Tests both `inactive → active` and `background → active` transitions
   - Tests that non-active transitions are properly ignored
   - All 7 scene phase tests pass successfully

### Files Modified

3. **`Sources/Controller/App/AppFeature.swift`**
   - Added `.scenePhaseChanged(old:new:)` action
   - Centralized refresh logic for both app launch and foreground transitions
   - Applied `.onSceneChange` modifier to AppView
   - Replaces individual `onAppear` handlers in tab views

## Technical Details

- Uses SwiftUI's recommended `@Environment(\.scenePhase)` approach
- **Centralized pattern**: All initialization happens in AppFeature, not in individual tabs
- Refreshes all tabs in parallel for optimal performance
- Reuses existing refresh actions (`.refresh`, `.refreshWindowStates`)
- Follows TCA patterns and clean architecture principles
- **No more onAppear needed**: Scene phase handling covers both initial load and foreground return

## Key Benefits

✅ **Centralized Logic**: Single source of truth for app initialization
✅ **Eliminates Redundancy**: No need for `onAppear` in individual tab views
✅ **Consistent Behavior**: Same refresh logic for launch and foreground return
✅ **Easier Maintenance**: Changes to initialization logic happen in one place

## Testing

✅ All unit tests pass (43 tests total, 7 for scene phase handling)
✅ SwiftLint compliance verified
✅ Swift Package builds successfully
✅ Tests verify both transition types trigger refresh

## Test Plan

- [ ] Launch app fresh → verify all tabs load data automatically
- [ ] Background the app and return → verify all tabs refresh
- [ ] Change data on server while backgrounded → verify updates appear on return
- [ ] Test rapid background/foreground transitions
- [ ] Test with network offline → verify graceful error handling

Closes #68