### PR TITLE
Improve MotionAtNight with configurable delay and parallel execution

### DIFF
--- a/Sources/HAImplementations/Automations/MotionAtNight.swift
+++ b/Sources/HAImplementations/Automations/MotionAtNight.swift
@@ -17,8 +17,12 @@ public struct MotionAtNight: Automatable {
 
     public var isActive = true
     public let name: String
-    public let noMotionWait: Duration
-    public let dimWait: Duration
+    /// Time to wait after last motion detection before starting the dim/off sequence
+    public private(set) var noMotionWait: Duration = .seconds(60)
+    /// Time to keep lights dimmed before turning them off completely
+    public private(set) var dimWait: Duration = .seconds(10)
+    /// Time to wait between turning on lights and setting color temperature to prevent flickering
+    public private(set) var colorTemperatureDelay: Duration = .seconds(1)
     public let motionSensors: [MotionSensorDevice]
     public let lightSensor: MotionSensorDevice
     public let windowContacts: [ContactSensorDevice]
@@ -31,10 +35,11 @@ public struct MotionAtNight: Automatable {
         Set(motionSensors.map(\.motionSensorId) + windowContacts.map(\.contactSensorId) + [lightSensor.lightSensorId!])
     }
 
-    public init(_ name: String, noMotionWait: Duration, dimWait: Duration = .seconds(10), motionSensors: [MotionSensorDevice], lightSensor: MotionSensorDevice, lights: [SwitchDevice], windowContacts: [ContactSensorDevice] = [], minBrightness: Float, maxBrightness: Float = 1, maxTemperature: Float = 1) {
+    public init(_ name: String, noMotionWait: Duration? = nil, dimWait: Duration? = nil, colorTemperatureDelay: Duration? = nil, motionSensors: [MotionSensorDevice], lightSensor: MotionSensorDevice, lights: [SwitchDevice], windowContacts: [ContactSensorDevice] = [], minBrightness: Float, maxBrightness: Float = 1, maxTemperature: Float = 1) {
         self.name = name
-        self.noMotionWait = noMotionWait
-        self.dimWait = dimWait
+        if let noMotionWait { self.noMotionWait = noMotionWait }
+        if let dimWait { self.dimWait = dimWait }
+        if let colorTemperatureDelay { self.colorTemperatureDelay = colorTemperatureDelay }
         self.motionSensors = motionSensors
         self.lightSensor = lightSensor
         self.lights = lights
@@ -86,42 +91,66 @@ public struct MotionAtNight: Automatable {
 
         let colorTemperatureValue = getNormalizedColorTemperatureValue().scale(to: 0.1...maxTemperature)
         let brightnessValue = getNormalizedBrightnessValue().scale(to: minBrightness...maxBrightness)
-        if !isWindowOpen {
 
+        if !isWindowOpen {
             log.debug("Adjusting lights")
+
             // We reduce the number of invocations/calls to the device to avoid flickering of it.
             // Note: First set brightness, then color temperature
-            for light in lights {
-                if light.brightnessId != nil {
-                    await light.setBrightness(to: brightnessValue, with: hm)
-                } else {
-                    await light.turnOn(with: hm)
+            await withTaskGroup(of: Void.self) { group in
+                // Each light runs its own sequence: turn on -> wait -> set color temperature
+                for light in lights {
+                    group.addTask {
+                        // Turn on the light
+                        if light.brightnessId != nil {
+                            await light.setBrightness(to: brightnessValue, with: hm)
+                        } else {
+                            await light.turnOn(with: hm)
+                        }
+
+                        // Wait before adjusting color temperature to prevent flickering
+                        try? await Task.sleep(for: colorTemperatureDelay)
+
+                        // Set color temperature if supported
+                        if light.hasColorTemperatureSupport {
+                            await light.setColorTemperature(to: colorTemperatureValue, with: hm)
+                        }
+                    }
                 }
-            }
 
-            try? await Task.sleep(for: .milliseconds(1000))
-
-            for light in lights where light.hasColorTemperatureSupport {
-                await light.setColorTemperature(to: colorTemperatureValue, with: hm)
+                // Wait for all lights to complete their sequence before proceeding
+                await group.waitForAll()
             }
 
             // wait for x seconds or until this task wil be suspended
             try await Task.sleep(for: noMotionWait)
         }
 
-        // dim lights before turning them of
+        // dim lights before turning them off
         log.debug("Dimming lights before turning them off")
-        for light in lights {
-            // do not change the brightness, if it is currently turned off
-            guard (try? await hm.getCurrentEntity(with: light.switchId).isDeviceOn ?? true) == true else { continue }
-            await light.setBrightness(to: min(0.05, brightnessValue), with: hm)
+        await withTaskGroup(of: Void.self) { group in
+            for light in lights {
+                group.addTask {
+                    // do not change the brightness, if it is currently turned off
+                    guard (try? await hm.getCurrentEntity(with: light.switchId).isDeviceOn ?? true) == true else { return }
+                    await light.setBrightness(to: min(0.05, brightnessValue), with: hm)
+                }
+            }
+
+            await group.waitForAll()
         }
         try await Task.sleep(for: dimWait)
 
-        // turn off lights
-        for light in lights {
-            log.debug("Turn off device \(light.switchId)")
-            await light.turnOff(with: hm)
+        // turn off lights in parallel
+        await withTaskGroup(of: Void.self) { group in
+            for light in lights {
+                group.addTask {
+                    log.debug("Turn off device \(light.switchId)")
+                    await light.turnOff(with: hm)
+                }
+            }
+
+            await group.waitForAll()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add configurable `colorTemperatureDelay` parameter (default: 1 second) to prevent flickering
- Refactor to use TaskGroup for parallel light operations across all phases  
- Improve performance by turning on, dimming, and turning off lights in parallel

## Changes
- **New Parameter**: `colorTemperatureDelay: Duration` with default value of `.seconds(1)`
  - Replaces hardcoded 1000ms delay
  - Fully configurable per automation instance
  - `Duration` type is Codable ✓

- **Parallel Execution**: All light operations now use `withTaskGroup`
  - Phase 1: Turn on all lights in parallel
  - Phase 2: Wait for `colorTemperatureDelay`, then set color temperature in parallel
  - Phase 3: Wait for motion timeout
  - Phase 4: Dim all lights in parallel
  - Phase 5: Turn off all lights in parallel

## Benefits
- Better performance through true parallel execution
- Cleaner, more consistent code structure
- Flexible timing configuration
- Reduced flickering with configurable delay

## Testing
- ✅ SwiftLint passed
- ✅ Swift build successful
- ✅ No compilation errors

## Files Modified
- `Sources/HAImplementations/Automations/MotionAtNight.swift`