### PR TITLE
Add window count badge to settings tab

### DIFF
--- a/Sources/Controller/App/AppFeature.swift
+++ b/Sources/Controller/App/AppFeature.swift
@@ -228,7 +228,7 @@ struct AppView: View {
                     )
                 )
             }
-            .badge(store.openWindowsCount)
+            .badge(store.openWindowsCount ?? 0)
         }
         .tabViewStyle(.sidebarAdaptable)
         .onSceneChange { oldPhase, newPhase in


### PR DESCRIPTION
## Summary
- Added a badge to the settings tab showing the number of currently open windows
- Badge displays the count from `windowContentState?.windowStates`
- Badge automatically hides when there are no windows or no data (returns `nil`)

## Changes
- Added `openWindowsCount` computed property to `AppFeature.State`
- Applied `.badge()` modifier to settings tab in `AppView`

## Test Plan
- [ ] Build and run the app
- [ ] Verify badge appears on settings tab when windows are open
- [ ] Verify badge shows correct count
- [ ] Verify badge updates when window states change
- [ ] Verify badge is hidden when no windows are open