### PR TITLE
Add skipColorTemperature property to SwitchDevice for HomeKit Adaptive Lighting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ HomeAutomation.xcodeproj/project.xcworkspace/xcuserdata
 HomeAutomation.xcodeproj/xcuserdata/juka.xcuserdatad
 HomeAutomationKit/.swiftpm/xcode/xcuserdata
 HomeAutomationKit/.build
+Apps/**/.build
 xcuserdata
 .env
 Client.d

--- a/Sources/HAImplementations/Entities/GenericSwitch.swift
+++ b/Sources/HAImplementations/Entities/GenericSwitch.swift
@@ -9,10 +9,11 @@ import Foundation
 import HAModels
 
 public final class GenericSwitch: SwitchDevice, @unchecked Sendable {
-    public convenience init(query: EntityId.Query) {
+    public convenience init(query: EntityId.Query, skipColorTemperature: Bool = false) {
         self.init(switchId: EntityId(query: query, characteristic: .switcher),
                   brightnessId: nil,
                   colorTemperatureId: nil,
-                  rgbId: nil)
+                  rgbId: nil,
+                  skipColorTemperature: skipColorTemperature)
     }
 }

--- a/Sources/HAImplementations/Entities/IkeaLightBulbColored.swift
+++ b/Sources/HAImplementations/Entities/IkeaLightBulbColored.swift
@@ -9,11 +9,12 @@ import Foundation
 import HAModels
 
 public final class IkeaLightBulbColored: SwitchDevice, @unchecked Sendable {
-    public convenience init(query: EntityId.Query) {
+    public convenience init(query: EntityId.Query, skipColorTemperature: Bool = false) {
         self.init(switchId: EntityId(query: query, characteristic: .switcher),
                   brightnessId: EntityId(query: query, characteristic: .brightness),
                   // IKEA light bulbs do not expose a color temperature property, so we need to use the RGB value for setting the temperature
                   colorTemperatureId: nil,
-                  rgbId: EntityId(query: query, characteristic: .color))
+                  rgbId: EntityId(query: query, characteristic: .color),
+                  skipColorTemperature: skipColorTemperature)
     }
 }

--- a/Sources/HAImplementations/Entities/LightBulbColored.swift
+++ b/Sources/HAImplementations/Entities/LightBulbColored.swift
@@ -9,10 +9,11 @@ import Foundation
 import HAModels
 
 public final class LightBulbColored: SwitchDevice, @unchecked Sendable {
-    public convenience init(query: EntityId.Query) {
+    public convenience init(query: EntityId.Query, skipColorTemperature: Bool = false) {
         self.init(switchId: EntityId(query: query, characteristic: .switcher),
                   brightnessId: EntityId(query: query, characteristic: .brightness),
                   colorTemperatureId: EntityId(query: query, characteristic: .colorTemperature),
-                  rgbId: EntityId(query: query, characteristic: .color))
+                  rgbId: EntityId(query: query, characteristic: .color),
+                  skipColorTemperature: skipColorTemperature)
     }
 }

--- a/Sources/HAImplementations/Entities/LightBulbDimmable.swift
+++ b/Sources/HAImplementations/Entities/LightBulbDimmable.swift
@@ -9,10 +9,11 @@ import Foundation
 import HAModels
 
 public final class LightBulbDimmable: SwitchDevice, @unchecked Sendable {
-    public convenience init(query: EntityId.Query) {
+    public convenience init(query: EntityId.Query, skipColorTemperature: Bool = false) {
         self.init(switchId: EntityId(query: query, characteristic: .switcher),
                   brightnessId: EntityId(query: query, characteristic: .brightness),
                   colorTemperatureId: nil,
-                  rgbId: nil)
+                  rgbId: nil,
+                  skipColorTemperature: skipColorTemperature)
     }
 }

--- a/Sources/HAImplementations/Entities/LightBulbWhite.swift
+++ b/Sources/HAImplementations/Entities/LightBulbWhite.swift
@@ -9,10 +9,11 @@ import Foundation
 import HAModels
 
 public final class LightBulbWhite: SwitchDevice, @unchecked Sendable {
-    public convenience init(query: EntityId.Query) {
+    public convenience init(query: EntityId.Query, skipColorTemperature: Bool = false) {
         self.init(switchId: EntityId(query: query, characteristic: .switcher),
                   brightnessId: EntityId(query: query, characteristic: .brightness),
                   colorTemperatureId: EntityId(query: query, characteristic: .colorTemperature),
-                  rgbId: nil)
+                  rgbId: nil,
+                  skipColorTemperature: skipColorTemperature)
     }
 }

--- a/Tests/HomeAutomationKitTests/SwitchDeviceTests.swift
+++ b/Tests/HomeAutomationKitTests/SwitchDeviceTests.swift
@@ -1,0 +1,153 @@
+//
+//  SwitchDeviceTests.swift
+//  HomeAutomationKit
+//
+//  Created by Julian Kahnert on 06.12.25.
+//
+
+import Foundation
+@testable import HAModels
+import Testing
+
+struct SwitchDeviceTests {
+
+    @Test("Test default skipColorTemperature is false")
+    func defaultSkipColorTemperature() throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .colorTemperature),
+            rgbId: nil
+        )
+
+        #expect(device.skipColorTemperature == false)
+    }
+
+    @Test("Test hasColorTemperatureSupport with colorTemperatureId and skip disabled")
+    func hasColorTemperatureSupportWithColorTempId() throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .colorTemperature),
+            rgbId: nil
+        )
+
+        #expect(device.hasColorTemperatureSupport == true)
+    }
+
+    @Test("Test hasColorTemperatureSupport with rgbId and skip disabled")
+    func hasColorTemperatureSupportWithRgbId() throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: nil,
+            rgbId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .color)
+        )
+
+        #expect(device.hasColorTemperatureSupport == true)
+    }
+
+    @Test("Test hasColorTemperatureSupport returns false when skip enabled")
+    func hasColorTemperatureSupportWithSkipEnabled() throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .colorTemperature),
+            rgbId: nil,
+            skipColorTemperature: true
+        )
+
+        #expect(device.skipColorTemperature == true)
+        #expect(device.hasColorTemperatureSupport == false)
+    }
+
+    @Test("Test hasColorTemperatureSupport returns false when no color support available")
+    func hasColorTemperatureSupportWithNoSupport() throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: nil,
+            rgbId: nil
+        )
+
+        #expect(device.hasColorTemperatureSupport == false)
+    }
+
+    @Test("Test setColorTemperature is skipped when skipColorTemperature is true")
+    func setColorTemperatureSkippedWhenFlagEnabled() async throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .colorTemperature),
+            rgbId: nil,
+            skipColorTemperature: true
+        )
+
+        let mockAdapter = await MockHomeAdapter()
+
+        // Call setColorTemperature - should be skipped
+        await device.setColorTemperature(to: 0.5, with: mockAdapter)
+
+        // Verify no setColorTemperature action was performed
+        let traceMap = await mockAdapter.getSortedTraceMap()
+        #expect(!traceMap.contains { $0.contains("setColorTemperature") })
+    }
+
+    @Test("Test setColorTemperature works normally when skip is false")
+    func setColorTemperatureWorksWhenSkipDisabled() async throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .colorTemperature),
+            rgbId: nil
+        )
+
+        let mockAdapter = await MockHomeAdapter()
+
+        // Call setColorTemperature - should work normally
+        await device.setColorTemperature(to: 0.5, with: mockAdapter)
+
+        // Verify setColorTemperature action was performed
+        let traceMap = await mockAdapter.getSortedTraceMap()
+        #expect(traceMap.contains("action.setColorTemperature: 1"))
+    }
+
+    @Test("Test setColorTemperature with RGB fallback when skip is false")
+    func setColorTemperatureWithRgbFallback() async throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: nil,
+            rgbId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .color)
+        )
+
+        let mockAdapter = await MockHomeAdapter()
+
+        // Call setColorTemperature - should use RGB fallback
+        await device.setColorTemperature(to: 0.5, with: mockAdapter)
+
+        // Verify setRGB action was performed (fallback)
+        let traceMap = await mockAdapter.getSortedTraceMap()
+        #expect(traceMap.contains("action.setRGB: 1"))
+    }
+
+    @Test("Test setColorTemperature with RGB fallback skipped when flag enabled")
+    func setColorTemperatureRgbFallbackSkipped() async throws {
+        let device = SwitchDevice(
+            switchId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher),
+            brightnessId: nil,
+            colorTemperatureId: nil,
+            rgbId: EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .color),
+            skipColorTemperature: true
+        )
+
+        let mockAdapter = await MockHomeAdapter()
+
+        // Call setColorTemperature - should be skipped even with RGB available
+        await device.setColorTemperature(to: 0.5, with: mockAdapter)
+
+        // Verify no RGB action was performed
+        let traceMap = await mockAdapter.getSortedTraceMap()
+        #expect(!traceMap.contains { $0.contains("setRGB") })
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #79 by adding an overridable `skipColorTemperature` property to the `SwitchDevice` base class. This allows devices using HomeKit's Adaptive Lighting feature to skip manual color temperature adjustments in automations like `MotionAtNight`.

## Changes

- Added `skipColorTemperature` property (default: `false`) to `SwitchDevice` base class
- Updated `hasColorTemperatureSupport` to return `false` when skip flag is enabled
- Updated `setColorTemperature()` to skip execution when flag is enabled with debug logging
- Added comprehensive unit tests covering all scenarios:
  - Default behavior (skipColorTemperature = false)
  - Overridden behavior (skipColorTemperature = true)
  - hasColorTemperatureSupport correctness
  - setColorTemperature() skip functionality
  - RGB fallback handling
- Updated `MockHomeAdapter` to properly conform to `HomeManagable` protocol

## Backward Compatibility

The implementation maintains full backward compatibility as the default behavior remains unchanged (`skipColorTemperature = false`). Existing devices and automations continue to work exactly as before.

## Usage

Subclasses can override the `skipColorTemperature` property to return `true` when Adaptive Lighting is being used:

\`\`\`swift
class MyAdaptiveLightBulb: SwitchDevice {
    override var skipColorTemperature: Bool { true }
}
\`\`\`

## Testing

- All unit tests pass
- `swift build` succeeds for HAModels and HAImplementations targets
- SwiftLint compliance verified

## Related Issue

Resolves #79