### PR TITLE
Enable HomeKit subscriptions for brightness and color

### DIFF
--- a/Sources/Adapter/Extensions/HMCharacteristic.swift
+++ b/Sources/Adapter/Extensions/HMCharacteristic.swift
@@ -362,9 +362,9 @@ extension HMCharacteristic: @retroactive Comparable {
         // We have to reduce the amount of events we subscribe to, because HomeKit can not handle all subscriptions.
         // It will leave skip important notifications like contactSensors.
         switch entityCharacteristicType {
-        case .motionSensor, .lightSensor, .switcher, .contactSensor, .carbonDioxideSensorId:
+        case .motionSensor, .lightSensor, .switcher, .contactSensor, .carbonDioxideSensorId, .brightness, .colorTemperature, .color:
             return true
-        case .batterySensor, .brightness, .colorTemperature, .color, .heating, .valve, .lock, .temperatureSensor, .relativeHumiditySensor, .pmDensitySensor, .airQualitySensor:
+        case .batterySensor, .heating, .valve, .lock, .temperatureSensor, .relativeHumiditySensor, .pmDensitySensor, .airQualitySensor:
             return false
         }
     }


### PR DESCRIPTION
Resolves #107

## Changes
- Modified `shouldSubscribe` property in `Sources/Adapter/Extensions/HMCharacteristic.swift` to include brightness, colorTemperature, and color characteristics
- Increases total subscribed characteristic types from 5 to 8

## Risk Assessment
⚠️ **Critical Monitoring Required**: This change increases HomeKit subscription count. If contact sensor notifications become unreliable, this must be reverted immediately (per commit b0466a1).

## Verification Strategy
### Phase 1: Immediate Testing (First 24 Hours)
- [ ] Monitor logs for brightness/color update events
- [ ] Test manual brightness changes via Home app
- [ ] Test manual color changes
- [ ] Test manual color temperature changes
- [ ] Verify events appear within 1-2 seconds

### Phase 2: Critical Sensor Monitoring
- [ ] Verify contact sensor notifications continue working reliably
- [ ] Monitor for 24-48 hours to ensure no degradation
- [ ] **If issues occur**: Revert immediately

### Phase 3: Database Verification
- [ ] Confirm brightness values stored correctly (0-100 range)
- [ ] Confirm color temperature normalized correctly (0.0-1.0 range)
- [ ] Confirm RGB values stored correctly
- [ ] Verify timestamps match adjustment times

### Phase 4: UI Verification
- [ ] Verify FlowKitController charts display real-time brightness data
- [ ] Verify color temperature changes visualized
- [ ] Verify color changes visualized

## Related Work
- Issue #107: Track brightness and Color
- PR #106: SetLightProperties automation for time-based light control
- Commit b0466a1: Reduced subscriptions due to HomeKit capacity limits
- Migration 03: Added brightness/color database fields

## Infrastructure
All supporting infrastructure already exists:
- ✅ Database schema (Migration 03)
- ✅ Domain models (EntityStorageItem)
- ✅ Database models (EntityStorageDbItem)
- ✅ API schema (openapi.yaml)
- ✅ HomeKit characteristic readers