### PR TITLE
Fix Live Activity push-to-start notifications

### DIFF
--- a/Sources/HAModels/PushNotifications/WindowContentState.swift
+++ b/Sources/HAModels/PushNotifications/WindowContentState.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct WindowContentState: Codable, Hashable, Sendable {
-    public static let activityTypeName = "WindowContentState"
+    public static let activityTypeName = "WindowAttributes"
     public let windowStates: [WindowState]
 
     public init(windowStates: [WindowState]) {


### PR DESCRIPTION
## Summary
- Fix Live Activity push-to-start by correcting `attributesType` from `"WindowContentState"` to `"WindowAttributes"`
- The APNS `attributesType` must match the `ActivityAttributes` struct name, not the `ContentState` name
- This regression was introduced in v0.0.8 (PR #103)

## Test plan
- [ ] Deploy to server (rebuild Docker image)
- [ ] Close FlowKit Controller app completely (remove from app switcher)
- [ ] Open a window
- [ ] Verify Live Activity appears on Lock Screen / Dynamic Island
- [ ] Check server logs for successful APNS delivery