### PR TITLE
Fix Live Activity update token registration when woken by push-to-start

### DIFF
--- a/Sources/Controller/App/AppDelegate.swift
+++ b/Sources/Controller/App/AppDelegate.swift
@@ -40,11 +40,12 @@ extension AppDelegate: UIApplicationDelegate {
                 return UIBackgroundFetchResult.failed
             }
 
-            // Send token to TCA store
+            // Send the activity's update token to TCA store and wait for completion.
+            // This token is used to send updates to the running Live Activity.
             let token = PushToken(deviceName: UIDevice.current.name,
                                   tokenString: deviceToken.hexadecimalString,
-                                  type: .pushNotification)
-            Self.store.send(.registerPushToken(token))
+                                  type: .liveActivityUpdate(activityName: WindowContentState.activityTypeName))
+            await Self.store.send(.registerPushToken(token)).finish()
 
             return UIBackgroundFetchResult.newData
         }


### PR DESCRIPTION
## Summary
- Fix token type when registering the activity's update token in `AppDelegate.didReceiveRemoteNotification`
- Changed from `.pushNotification` to `.liveActivityUpdate(activityName:)`

## Problem
When the app was woken by a push-to-start notification:
1. The app received the activity's `pushToken` (for updates)
2. But registered it as `.pushNotification` instead of `.liveActivityUpdate`
3. The server couldn't find a matching `liveActivityUpdate` token
4. Updates didn't work unless the app was brought to foreground (which triggers `startMonitoringLiveActivities`)

## Test plan
- [ ] Build iOS app with fix
- [ ] Delete all tokens from database
- [ ] Open app to register `liveActivityStart` token
- [ ] Close app completely
- [ ] Open a window → Live Activity should start via push
- [ ] Open another window → Live Activity should update (without opening app)