### PR TITLE
Replace swift-actions with vapor/swiftly-action

### DIFF
--- a/.github/workflows/renovate-package-resolved.yaml
+++ b/.github/workflows/renovate-package-resolved.yaml
@@ -19,9 +19,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
+        uses: vapor/swiftly-action@v0.2
         with:
-          swift-version: "6"
+          toolchain: latest
 
       - name: Run swift package resolve
         run: swift package resolve


### PR DESCRIPTION
## Summary
- Replaced `swift-actions/setup-swift@v2` with `vapor/swiftly-action@v0.2` in the Renovate workflow
- Updated parameter from `swift-version: "6"` to `toolchain: latest`

## Changes
- Updated `.github/workflows/renovate-package-resolved.yaml`

## Rationale
Using the official Vapor swiftly-action provides better integration with Swift toolchain management.