### PR TITLE
Log adapter errors before distributed actor serialization

### DIFF
--- a/Sources/Adapter/DistributedActors/HomeKitCommandReceiver.swift
+++ b/Sources/Adapter/DistributedActors/HomeKitCommandReceiver.swift
@@ -45,14 +45,25 @@ public distributed actor HomeKitCommandReceiver {
     }
 
     public distributed func perform(_ action: HomeManagableAction) async throws {
-        try await adapter.perform(action)
+        do {
+            try await adapter.perform(action)
+        } catch {
+            log.critical("perform(_:) — failed action '\(action)': \(error)")
+            throw error
+        }
     }
 
     public distributed func trigger(scene sceneName: String) async throws {
         log.info("trigger(scene:) — received remote call for '\(sceneName)'")
         let start = ContinuousClock.now
-        try await adapter.trigger(scene: sceneName)
-        let duration = start.duration(to: .now)
-        log.info("trigger(scene:) — completed '\(sceneName)' in \(duration)")
+        do {
+            try await adapter.trigger(scene: sceneName)
+            let duration = start.duration(to: .now)
+            log.info("trigger(scene:) — completed '\(sceneName)' in \(duration)")
+        } catch {
+            let duration = start.duration(to: .now)
+            log.critical("trigger(scene:) — failed '\(sceneName)' after \(duration): \(error)")
+            throw error
+        }
     }
 }

--- a/Sources/Adapter/HomeKitAdapter+Delegates.swift
+++ b/Sources/Adapter/HomeKitAdapter+Delegates.swift
@@ -55,7 +55,12 @@ extension HomeKitAdapter {
             let home = try actionSet.home.get(with: log)
 
             log.info("Executing action set: \(actionSet.name) [\(home.description)]")
-            try await home.executeActionSet(actionSet)
+            do {
+                try await home.executeActionSet(actionSet)
+            } catch {
+                log.critical("Failed to execute action set '\(actionSet.name)': \(error)")
+                throw error
+            }
         }
 
         func updateEntities() async {
@@ -172,7 +177,7 @@ extension HomeKitAdapter.HomeKitHomeManager: HMHomeDelegate {
     }
 
     func home(_ home: HMHome, didEncounterError error: any Error, for accessory: HMAccessory) {
-        log.info("home:didEncounterError accessory \(accessory.name)")
+        log.error("home:didEncounterError accessory '\(accessory.name)': \(error)")
         update(homes: manager.homes)
     }
 

--- a/Sources/Adapter/HomeKitAdapter.swift
+++ b/Sources/Adapter/HomeKitAdapter.swift
@@ -170,7 +170,12 @@ public final class HomeKitAdapter: HomeKitAdapterable {
 
     public func trigger(scene sceneName: String) async throws {
         log.info("triggering scene: \(sceneName)")
-        try await homeKitHomeManager.trigger(scene: sceneName)
+        do {
+            try await homeKitHomeManager.trigger(scene: sceneName)
+        } catch {
+            log.critical("Failed to trigger scene '\(sceneName)': \(error)")
+            throw error
+        }
     }
 
     /// Attention: This call might take a while so be carefull with it


### PR DESCRIPTION
## Summary
- Log errors at every adapter layer (HomeKitHomeManager, HomeKitAdapter, HomeKitCommandReceiver) before they are thrown and serialized by the distributed actor system
- Errors from HomeKit (NSError) get wrapped into `GenericRemoteCallError` during serialization, losing code, domain, and description — this ensures the full error appears in adapter logs
- Fix `didEncounterError` delegate that was ignoring the `error` parameter entirely

## Test plan
- [ ] Deploy updated adapter and trigger a scene that previously failed
- [ ] Verify adapter logs now show the full HomeKit error (e.g. NSError domain/code/description)
- [ ] Verify `didEncounterError` delegate logs the actual error for accessory issues