### PR TITLE
Add health check endpoint and DB connection pool timeout

### DIFF
--- a/Sources/Server/configure.swift
+++ b/Sources/Server/configure.swift
@@ -102,7 +102,8 @@ public func configure(_ app: Application) async throws {
             username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",
             password: Environment.get("DATABASE_PASSWORD") ?? "vapor_password",
             database: Environment.get("DATABASE_NAME") ?? "vapor_database",
-            tlsConfiguration: tlsConfiguration
+            tlsConfiguration: tlsConfiguration,
+            connectionPoolTimeout: .seconds(10)
         ), as: .mysql)
 
     app.migrations.add(CreateEntityStorageDbItem())

--- a/Sources/Server/routes.swift
+++ b/Sources/Server/routes.swift
@@ -1,6 +1,7 @@
 import HAImplementations
 import HAModels
 import OpenAPIVapor
+import SQLKit
 import Vapor
 
 func routes(_ app: Application) throws {
@@ -16,6 +17,14 @@ func routes(_ app: Application) throws {
     // Manual routes - now protected
     authenticatedRoutes.get { _ async in
         "It works!"
+    }
+
+    authenticatedRoutes.get("health") { req async throws -> HTTPStatus in
+        guard let sql = req.db as? any SQLDatabase else {
+            throw Abort(.internalServerError, reason: "Database does not support SQL queries")
+        }
+        try await sql.raw("SELECT 1").run()
+        return .ok
     }
 
     authenticatedRoutes.get("config") { req in


### PR DESCRIPTION
## Summary

- Adds `/health` endpoint (authenticated) that tests DB connectivity via `SELECT 1` — enables Docker healthchecks to detect frozen server state
- Sets explicit `connectionPoolTimeout: .seconds(10)` on MySQL connection pool config
- Closes #126

## Test plan

- [ ] `swift build` passes
- [ ] Deploy and verify `curl -H "Authorization: Bearer $AUTH_TOKEN" http://localhost:8080/health` returns 200
- [ ] Add Docker healthcheck to docker-compose.yml (see #126 for config)
- [ ] Verify Docker marks container as unhealthy when DB is unreachable