### PR TITLE
Add curl to Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q install -y \
       libjemalloc2 \
       ca-certificates \
+      curl \
       tzdata \
 # If your app or its dependencies import FoundationNetworking, also install `libcurl4`.
       libcurl4 \


### PR DESCRIPTION
## Summary
- Adds `curl` package to the runtime Docker image to enable simplified healthcheck commands
- Allows replacing the complex bash `/dev/tcp` healthcheck with a simple `curl -sf` call

## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Verify `curl` is available inside the running container
- [ ] Verify healthcheck works with `curl -sf -H 'Authorization: Bearer $AUTH_TOKEN' http://localhost:8080/health`