### PR TITLE
Fix Live Activity silent start, token upsert, and stale token deletion bug

### DIFF
--- a/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
+++ b/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
@@ -40,20 +40,14 @@ struct FlowKitAdapter: App, Log {
                 entities: $entities,
                 connectionStatus: $connectionStatus
             )
-            .task {
-                Self.log.info("runloop task called")
+            .task(id: serverAddress) {
+                Self.log.info("runloop task called for address: \(serverAddress)")
 
                 // do not start run loop when running in preview canvas
                 guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return }
 
                 try? await Task.sleep(for: .seconds(1))
                 await initializeActorSystem()
-            }
-            .onChange(of: serverAddress) { _, newValue in
-                Task {
-                    Self.log.info("Server address changed to \(newValue), reinitializing actor system")
-                    await initializeActorSystem()
-                }
             }
         }
     }

--- a/Sources/Server/Controllers/OpenAPIController.swift
+++ b/Sources/Server/Controllers/OpenAPIController.swift
@@ -69,19 +69,21 @@ struct OpenAPIController: APIProtocol {
         case .pushNotification, .liveActivityStart:
             assert(token.activityType == nil, "For pushNotification and liveActivityStart, activityType should be nil")
 
-            // first delete all previous token
-            try await DeviceToken
+            // upsert: update existing token or create new one
+            if let existing = try await DeviceToken
                 .query(on: request.db)
                 .filter(\.$deviceName == token.deviceName)
                 .filter(\.$tokenType == token.tokenType.rawValue)
-                .delete()
-
-            // add the new token
-            let newPushDevice = DeviceToken(deviceName: token.deviceName,
-                                            tokenString: token.tokenString,
-                                            tokenType: token.tokenType.rawValue,
-                                            activityType: token.activityType) // for pushNotification & liveActivityStart - this should always be nil
-            try await newPushDevice.save(on: request.db)
+                .first() {
+                existing.tokenString = token.tokenString
+                try await existing.save(on: request.db)
+            } else {
+                let newPushDevice = DeviceToken(deviceName: token.deviceName,
+                                                tokenString: token.tokenString,
+                                                tokenType: token.tokenType.rawValue,
+                                                activityType: token.activityType)
+                try await newPushDevice.save(on: request.db)
+            }
             return .ok
 
         case .liveActivityUpdate:
@@ -90,29 +92,20 @@ struct OpenAPIController: APIProtocol {
                 return .internalServerError
             }
 
-            // delete other tokens with that activity type
-            try await DeviceToken
+            // upsert: update existing token or create new one
+            if let existing = try await DeviceToken
                 .query(on: request.db)
                 .filter(\.$deviceName == token.deviceName)
-                .filter(\.$tokenString != token.tokenString)
                 .filter(\.$tokenType == token.tokenType.rawValue)
                 .filter(\.$activityType == activityType)
-                .delete()
-
-            // insert the new token, if needed
-            let numberOfPushDevices = try await DeviceToken
-                .query(on: request.db)
-                .filter(\.$deviceName == token.deviceName)
-                .filter(\.$tokenString == token.tokenString)
-                .filter(\.$tokenType == token.tokenType.rawValue)
-                .filter(\.$activityType == activityType)
-                .count()
-            if numberOfPushDevices == 0 {
+                .first() {
+                existing.tokenString = token.tokenString
+                try await existing.save(on: request.db)
+            } else {
                 let newPushDevice = DeviceToken(deviceName: token.deviceName,
                                                 tokenString: token.tokenString,
                                                 tokenType: token.tokenType.rawValue,
                                                 activityType: activityType)
-
                 try await newPushDevice.save(on: request.db)
             }
             return .ok

--- a/Sources/Server/Controllers/PushNotifcationService.swift
+++ b/Sources/Server/Controllers/PushNotifcationService.swift
@@ -74,7 +74,7 @@ actor PushNotifcationService: NotificationSender {
                     // delete liveActivityUpdate tokens that are older than 4 hours
                     try await DeviceToken
                         .query(on: database)
-                        .filter(\.$id != tokenId)
+                        .filter(\.$id == tokenId)
                         .delete()
 
                 } else {
@@ -117,9 +117,7 @@ actor PushNotifcationService: NotificationSender {
                             timestamp: Int(Date().timeIntervalSince1970),
                             attributes: contentState,
                             attributesType: activityName,
-                            alert: APNSAlertNotificationContent(
-                                title: .raw("empty"),
-                                body: .raw("empty")))
+                            alert: APNSAlertNotificationContent())
 
                         // start a new live activity
                         usedToken = startToken


### PR DESCRIPTION
## Summary

- **Live Activity silent start**: `APNSStartLiveActivityNotification` wird jetzt mit leerem `APNSAlertNotificationContent()` gesendet – kein Banner beim Starten der Live Activity. Der eigentliche Alert kommt erst nach `maxOpenDuration` via `sendNotification`.
- **Stale token deletion bug fix**: Invertierter Filter (`.filter(\.$id != tokenId)`) hat ALLE anderen Tokens gelöscht statt nur den alten Token. Korrigiert auf `.filter(\.$id == tokenId)`.
- **Token upsert**: `OpenAPIController` nutzt jetzt ein Upsert-Pattern (update wenn vorhanden, sonst insert) statt delete+insert für Device Tokens – robuster gegen Race Conditions.
- **FlowKitAdapter task restart**: `.onChange(of: serverAddress)` + `.task` ersetzt durch `.task(id: serverAddress)`, sodass der Runloop automatisch bei Server-Adressänderung neu startet.

## Test plan

- [ ] Fenster öffnen → Live Activity startet **ohne** Notification-Banner
- [ ] Fenster bleibt offen > `maxOpenDuration` → Alert-Notification wird gesendet
- [ ] Fenster schließen vor Ablauf → Live Activity endet, kein Alert
- [ ] Token-Registrierung bei wiederholtem App-Start erzeugt keinen doppelten DB-Eintrag
- [ ] Server-Adresse in FlowKitAdapter ändern → Verbindung wird neu aufgebaut