### PR TITLE
Add GitHub Release creation to tag workflow

### DIFF
--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -10,6 +10,46 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep -A1 "^$TAG$" | tail -1)
+
+          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
+            NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+              -f tag_name="$TAG" \
+              -f previous_tag_name="$PREV_TAG" \
+              --jq '.body')
+          else
+            NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+              -f tag_name="$TAG" \
+              --jq '.body')
+          fi
+
+          {
+            echo 'body<<EOF'
+            echo "$NOTES"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.notes.outputs.body }}
+
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Adds a `create-release` job to `docker-tag.yaml` that runs in parallel with the existing Docker build when a version tag is pushed
- Generates release notes via `gh api .../releases/generate-notes` (same approach as HeadsUpKit)
- Determines the previous tag automatically for a proper diff range
- Creates a GitHub Release with the generated notes via `softprops/action-gh-release@v2`

## Test plan

- [ ] Push a version tag and verify a GitHub Release is created with auto-generated notes
- [ ] Docker image build continues to work as before