### PR TITLE
Fix push-to-start Live Activity: restore required alert content

### DIFF
--- a/Sources/Server/Controllers/PushNotifcationService.swift
+++ b/Sources/Server/Controllers/PushNotifcationService.swift
@@ -109,6 +109,10 @@ actor PushNotifcationService: NotificationSender {
                         $0.tokenType == "liveActivityStart"
                     }) {
                         Self.logger.info("Starting LiveActivity (on: \(startToken.deviceName)) with attributesType '\(activityName)': \(contentState)")
+                        // alert with non-empty title/body is required for push-to-start Live Activities
+                        // to be displayed on the device. Omitting or using an empty
+                        // APNSAlertNotificationContent() causes iOS to silently drop the notification
+                        // and the Live Activity will never appear.
                         let notification = APNSStartLiveActivityNotification<ContentState, ContentState>(
                             expiration: .none,
                             priority: .immediately,
@@ -117,7 +121,9 @@ actor PushNotifcationService: NotificationSender {
                             timestamp: Int(Date().timeIntervalSince1970),
                             attributes: contentState,
                             attributesType: activityName,
-                            alert: APNSAlertNotificationContent())
+                            alert: APNSAlertNotificationContent(
+                                title: .raw("empty"),
+                                body: .raw("empty")))
 
                         // start a new live activity
                         usedToken = startToken


### PR DESCRIPTION
## Summary

- Restores `title: .raw("empty"), body: .raw("empty")` in `APNSStartLiveActivityNotification`
- Adds a comment documenting why a non-empty alert is mandatory

## Background

Per testing, iOS silently drops push-to-start notifications when `APNSAlertNotificationContent` has no title/body — the Live Activity never appears on the device. Apple's APNS documentation lists `alert` as optional, but in practice a non-empty title and body are required for the Live Activity to be shown.

## Test plan

- [ ] Window opens → Live Activity appears on device