### PR TITLE
Add adapter connection check to /health endpoint

### DIFF
--- a/Sources/Server/routes.swift
+++ b/Sources/Server/routes.swift
@@ -24,6 +24,12 @@ func routes(_ app: Application) throws {
             throw Abort(.internalServerError, reason: "Database does not support SQL queries")
         }
         try await sql.raw("SELECT 1").run()
+
+        let connectionStatus = await req.application.customActorSystem.latestConnectionStatus
+        guard connectionStatus == .up else {
+            throw Abort(.serviceUnavailable, reason: "Adapter connection status: \(String(describing: connectionStatus))")
+        }
+
         return .ok
     }
 


### PR DESCRIPTION
## Summary
- `/health` endpoint now also checks adapter connection status
- Returns 503 Service Unavailable when adapter is not connected
- Provides visibility into connection issues via Docker healthcheck

## Context
Builds on #144. The health endpoint previously only checked database connectivity. Now it also verifies the adapter cluster connection, so Docker healthcheck and external monitoring can detect adapter disconnects.

## Test plan
- [ ] Verify `/health` returns 200 when adapter is connected
- [ ] Verify `/health` returns 503 when adapter is disconnected