### PR TITLE
Fix Swift Testing anti-patterns

### DIFF
--- a/Tests/HomeAutomationKitTests/HelperTests/CircadianLightTests.swift
+++ b/Tests/HomeAutomationKitTests/HelperTests/CircadianLightTests.swift
@@ -12,7 +12,7 @@ import Testing
 struct CircadianTests {
 
     /// Helper function to create a specific date
-    private func date(year: Int, month: Int, day: Int, hour: Int, minute: Int) -> Date {
+    private func date(year: Int, month: Int, day: Int, hour: Int, minute: Int) throws -> Date {
         var dateComponents = DateComponents()
         dateComponents.year = year
         dateComponents.month = month
@@ -20,12 +20,12 @@ struct CircadianTests {
         dateComponents.hour = hour
         dateComponents.minute = minute
         let calendar = Calendar.current
-        return calendar.date(from: dateComponents)!
+        return try #require(calendar.date(from: dateComponents))
     }
 
     @Test("Test case for when the date is during the day (between sunrise and sunset)")
-    func testCircadianPercentage_Daytime() {
-        let date = self.date(year: 2023, month: 7, day: 25, hour: 12, minute: 0) // Solar noon
+    func testCircadianPercentage_Daytime() throws {
+        let date = try self.date(year: 2023, month: 7, day: 25, hour: 12, minute: 0) // Solar noon
 
         let sunData = getSunData(for: date)
         let percentage = getNormalizedBrightnessValue(sunData: sunData, current: date.percentageOfDay())
@@ -35,11 +35,11 @@ struct CircadianTests {
     }
 
     @Test("Test case for when the date is during the night (between sunset and sunrise)", .tags(.localOnly))
-    func testCircadianPercentage_Nighttime() {
+    func testCircadianPercentage_Nighttime() throws {
         setenv("TZ", "Europe/Berlin", 1)
         CFTimeZoneResetSystem()
 
-        let date = self.date(year: 2023, month: 7, day: 25, hour: 2, minute: 0) // During night
+        let date = try self.date(year: 2023, month: 7, day: 25, hour: 2, minute: 0) // During night
 
         let sunData = getSunData(for: date)
         let percentage = getNormalizedBrightnessValue(sunData: sunData, current: date.percentageOfDay())
@@ -49,8 +49,8 @@ struct CircadianTests {
     }
 
     @Test("Test case for when there's no sunrise or sunset (e.g., polar regions during certain seasons)")
-    func testCircadianPercentage_NoSunriseSunset() {
-        let date = self.date(year: 2023, month: 7, day: 25, hour: 12, minute: 0)
+    func testCircadianPercentage_NoSunriseSunset() throws {
+        let date = try self.date(year: 2023, month: 7, day: 25, hour: 12, minute: 0)
 
         let sunData = getSunData(for: date)
         let percentage = getNormalizedBrightnessValue(sunData: sunData, current: date.percentageOfDay())

--- a/Tests/HomeAutomationKitTests/RealworldAutomationTests/SetLightPropertiesTests.swift
+++ b/Tests/HomeAutomationKitTests/RealworldAutomationTests/SetLightPropertiesTests.swift
@@ -45,8 +45,8 @@ struct SetLightPropertiesTests {
         // Should call setRGB for both lights
         #expect(traceMap.contains("action.setRGB: 2"))
         // Should not call setColorTemperature or setBrightness
-        #expect(!traceMap.contains { $0.contains("setColorTemperature") })
-        #expect(!traceMap.contains { $0.contains("setBrightness") })
+        #expect(traceMap.contains { $0.contains("setColorTemperature") } == false)
+        #expect(traceMap.contains { $0.contains("setBrightness") } == false)
     }
 
     @Test("Test with only color temperature set")
@@ -69,8 +69,8 @@ struct SetLightPropertiesTests {
         // Should call setColorTemperature for both lights
         #expect(traceMap.contains("action.setColorTemperature: 2"))
         // Should not call setRGB or setBrightness
-        #expect(!traceMap.contains { $0.contains("setRGB") })
-        #expect(!traceMap.contains { $0.contains("setBrightness") })
+        #expect(traceMap.contains { $0.contains("setRGB") } == false)
+        #expect(traceMap.contains { $0.contains("setBrightness") } == false)
     }
 
     @Test("Test with only brightness set")
@@ -93,8 +93,8 @@ struct SetLightPropertiesTests {
         // Should call setBrightness for both lights
         #expect(traceMap.contains("action.setBrightness: 2"))
         // Should not call setRGB or setColorTemperature
-        #expect(!traceMap.contains { $0.contains("setRGB") })
-        #expect(!traceMap.contains { $0.contains("setColorTemperature") })
+        #expect(traceMap.contains { $0.contains("setRGB") } == false)
+        #expect(traceMap.contains { $0.contains("setColorTemperature") } == false)
     }
 
     @Test("Test with all properties set")
@@ -138,9 +138,9 @@ struct SetLightPropertiesTests {
         let traceMap = mockAdapter.getSortedTraceMap()
 
         // Should not perform any actions
-        #expect(!traceMap.contains { $0.contains("setRGB") })
-        #expect(!traceMap.contains { $0.contains("setColorTemperature") })
-        #expect(!traceMap.contains { $0.contains("setBrightness") })
+        #expect(traceMap.contains { $0.contains("setRGB") } == false)
+        #expect(traceMap.contains { $0.contains("setColorTemperature") } == false)
+        #expect(traceMap.contains { $0.contains("setBrightness") } == false)
     }
 
     @Test("Test that delays are applied between property types")
@@ -220,7 +220,7 @@ struct SetLightPropertiesTests {
         components.month = 7
         components.day = 20
         let calendar = Calendar.current
-        let correctDate = calendar.date(from: components)!
+        let correctDate = try #require(calendar.date(from: components))
         let correctEvent = HomeEvent.time(date: correctDate)
 
         // Should trigger at the correct time
@@ -234,7 +234,7 @@ struct SetLightPropertiesTests {
         incorrectComponents.year = 2024
         incorrectComponents.month = 7
         incorrectComponents.day = 20
-        let incorrectDate = calendar.date(from: incorrectComponents)!
+        let incorrectDate = try #require(calendar.date(from: incorrectComponents))
         let incorrectEvent = HomeEvent.time(date: incorrectDate)
 
         let shouldNotTrigger = try await automation.shouldTrigger(with: incorrectEvent, using: mockAdapter)

--- a/Tests/HomeAutomationKitTests/SwitchDeviceTests.swift
+++ b/Tests/HomeAutomationKitTests/SwitchDeviceTests.swift
@@ -90,7 +90,7 @@ struct SwitchDeviceTests {
 
         // Verify no setColorTemperature action was performed
         let traceMap = await mockAdapter.getSortedTraceMap()
-        #expect(!traceMap.contains { $0.contains("setColorTemperature") })
+        #expect(traceMap.contains { $0.contains("setColorTemperature") } == false)
     }
 
     @Test("Test setColorTemperature works normally when skip is false")
@@ -148,6 +148,6 @@ struct SwitchDeviceTests {
 
         // Verify no RGB action was performed
         let traceMap = await mockAdapter.getSortedTraceMap()
-        #expect(!traceMap.contains { $0.contains("setRGB") })
+        #expect(traceMap.contains { $0.contains("setRGB") } == false)
     }
 }


### PR DESCRIPTION
## Summary

- Replace `!` negation inside `#expect` with `== false` across 3 test files (11 occurrences) — `!` defeats Swift Testing's macro expansion, producing unhelpful failure diagnostics
- Replace force unwraps (`!`) with `try #require` for graceful test failures instead of test runner crashes (3 occurrences)

### Files changed

- **CircadianLightTests.swift** — Helper `date()` function now `throws` and uses `try #require` instead of force unwrap
- **SwitchDeviceTests.swift** — 2 `#expect(!...)` → `#expect(... == false)`
- **SetLightPropertiesTests.swift** — 9 `#expect(!...)` → `#expect(... == false)`, 2 force unwraps → `try #require`

## Test plan

- [x] `swift build` passes
- [x] `swift build --build-tests` passes
- [ ] `swift test` passes (CI)