### PR TITLE
Fix onlyBeforeSunrise race condition at minute boundary

### DIFF
--- a/Sources/HAImplementations/Automations/Turn.swift
+++ b/Sources/HAImplementations/Automations/Turn.swift
@@ -35,15 +35,18 @@ public struct Turn: Automatable {
     public func shouldTrigger(with event: HomeEvent, using hm: HomeManagable) async throws -> Bool {
         if onlyBeforeSunrise {
             let isTimeEqual = time.isEqual(event)
+            guard isTimeEqual else { return false }
 
+            // Uses Sun.sunriseElevation — the same method ClockJob uses to
+            // emit .sunrise events — so both always agree on the sunrise minute.
             let location = await hm.getLocation()
-            let elevation = Sun.position(latitude: location.latitude, longitude: location.longitude, date: Date())?.elevation
-            guard let elevation else {
-                assertionFailure("Failed to get sun elevation")
-                return isTimeEqual
+            guard case .time(let date) = event else { return false }
+            guard let elevation = Sun.sunriseElevation(for: date, latitude: location.latitude, longitude: location.longitude) else {
+                assertionFailure("Failed to get sunrise time")
+                return true
             }
 
-            return isTimeEqual && elevation < 0
+            return elevation == .below
         } else {
             return time.isEqual(event)
         }

--- a/Sources/HAModels/Helper/Sun.swift
+++ b/Sources/HAModels/Helper/Sun.swift
@@ -53,6 +53,41 @@ public struct SunSchedule {
 }
 
 public class Sun {
+
+    /// Relation of a date to a sun event, compared at minute granularity.
+    public enum SunElevation {
+        case below
+        case horizon
+        case above
+    }
+
+    /// Returns the sun elevation state relative to sunrise for the given date.
+    /// Used by both `ClockJob` and `Turn.onlyBeforeSunrise` to ensure consistent behavior.
+    public static func sunriseElevation(for date: Date, latitude: Double, longitude: Double, timeZone: TimeZone = .current) -> SunElevation? {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        guard let schedule = Self.schedule(latitude: latitude, longitude: longitude, date: date, calendar: calendar, timeZone: timeZone),
+              let sunrise = schedule.sunrise else { return nil }
+        return switch calendar.compare(date, to: sunrise.date, toGranularity: .minute) {
+        case .orderedAscending: .below
+        case .orderedSame: .horizon
+        case .orderedDescending: .above
+        }
+    }
+
+    /// Returns the sun elevation state relative to sunset for the given date.
+    public static func sunsetElevation(for date: Date, latitude: Double, longitude: Double, timeZone: TimeZone = .current) -> SunElevation? {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        guard let schedule = Self.schedule(latitude: latitude, longitude: longitude, date: date, calendar: calendar, timeZone: timeZone),
+              let sunset = schedule.sunset else { return nil }
+        return switch calendar.compare(date, to: sunset.date, toGranularity: .minute) {
+        case .orderedAscending: .above
+        case .orderedSame: .horizon
+        case .orderedDescending: .below
+        }
+    }
+
     public static func schedule(latitude: Double, longitude: Double, date: Date?) -> SunSchedule? {
         return schedule(latitude: latitude, longitude: longitude, date: date, calendar: nil, timeZone: nil)
     }

--- a/Sources/Server/Jobs/ClockJob.swift
+++ b/Sources/Server/Jobs/ClockJob.swift
@@ -21,12 +21,9 @@ struct ClockJob: Job, Log {
             homeEventsContinuation.yield(.time(date: date))
 
             // trigger sunset/sunrise event
-            let sunSchedule = Sun.schedule(latitude: location.latitude, longitude: location.longitude, date: date)
-            if let sunrise = sunSchedule?.sunrise,
-               Calendar.current.isDate(sunrise.date, equalTo: date, toGranularity: .minute) {
+            if Sun.sunriseElevation(for: date, latitude: location.latitude, longitude: location.longitude) == .horizon {
                 homeEventsContinuation.yield(.sunrise)
-            } else if let sunset = sunSchedule?.sunset,
-                      Calendar.current.isDate(sunset.date, equalTo: date, toGranularity: .minute) {
+            } else if Sun.sunsetElevation(for: date, latitude: location.latitude, longitude: location.longitude) == .horizon {
                 homeEventsContinuation.yield(.sunset)
             }
         }

--- a/Tests/HomeAutomationKitTests/HelperTests/SunComparisonTests.swift
+++ b/Tests/HomeAutomationKitTests/HelperTests/SunComparisonTests.swift
@@ -1,0 +1,115 @@
+//
+//  SunComparisonTests.swift
+//  HomeAutomationKit
+//
+//  Created by Julian Kahnert on 20.03.26.
+//
+
+import Foundation
+@testable import HAModels
+import Testing
+
+struct SunComparisonTests {
+
+    // Oldenburg, Germany
+    private let latitude = 53.14194
+    private let longitude = 8.21292
+    private let timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+    private func date(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int = 0) throws -> Date {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        return try #require(calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour, minute: minute, second: second)))
+    }
+
+    private func sunriseComponents(year: Int, month: Int, day: Int) throws -> (hour: Int, minute: Int) {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        let refDate = try date(year: year, month: month, day: day, hour: 12, minute: 0)
+        let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
+        let sunrise = try #require(schedule.sunrise)
+        return (calendar.component(.hour, from: sunrise.date), calendar.component(.minute, from: sunrise.date))
+    }
+
+    // MARK: - sunriseElevation
+
+    @Test("Well before sunrise returns .below")
+    func wellBeforeSunrise() throws {
+        let testDate = try date(year: 2026, month: 3, day: 20, hour: 4, minute: 0)
+        #expect(Sun.sunriseElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .below)
+    }
+
+    @Test("One minute before sunrise returns .below")
+    func oneMinuteBeforeSunrise() throws {
+        let (h, m) = try sunriseComponents(year: 2026, month: 3, day: 20)
+        let testDate = try date(year: 2026, month: 3, day: 20, hour: h, minute: m - 1)
+        #expect(Sun.sunriseElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .below)
+    }
+
+    @Test("Same minute as sunrise returns .horizon")
+    func sameMinuteAsSunrise() throws {
+        let (h, m) = try sunriseComponents(year: 2026, month: 3, day: 20)
+        let testDate = try date(year: 2026, month: 3, day: 20, hour: h, minute: m)
+        #expect(Sun.sunriseElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .horizon)
+    }
+
+    @Test("One minute after sunrise returns .above")
+    func oneMinuteAfterSunrise() throws {
+        let (h, m) = try sunriseComponents(year: 2026, month: 3, day: 20)
+        let testDate = try date(year: 2026, month: 3, day: 20, hour: h, minute: m + 1)
+        #expect(Sun.sunriseElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .above)
+    }
+
+    @Test("Well after sunrise returns .above")
+    func wellAfterSunrise() throws {
+        let testDate = try date(year: 2026, month: 3, day: 20, hour: 10, minute: 0)
+        #expect(Sun.sunriseElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .above)
+    }
+
+    // MARK: - Edge case: spring equinox (sunrise close to 06:30)
+
+    @Test("Spring equinox: automation at sunrise+1min must not be .below")
+    func springEquinoxEdgeCase() throws {
+        let (h, m) = try sunriseComponents(year: 2026, month: 3, day: 20)
+        let automationDate = try date(year: 2026, month: 3, day: 20, hour: h, minute: m + 1)
+        let result = Sun.sunriseElevation(for: automationDate, latitude: latitude, longitude: longitude, timeZone: timeZone)
+        #expect(result != .below, "Automation at \(h):\(m + 1) must not trigger when sunrise is at \(h):\(m)")
+    }
+
+    // MARK: - Seconds precision: both :00 and :59 of the same minute yield identical results
+
+    @Test("Seconds within sunrise minute do not affect result")
+    func secondsWithinSunriseMinute() throws {
+        let (h, m) = try sunriseComponents(year: 2026, month: 3, day: 20)
+        let atSecond0 = try date(year: 2026, month: 3, day: 20, hour: h, minute: m, second: 0)
+        let atSecond15 = try date(year: 2026, month: 3, day: 20, hour: h, minute: m, second: 15)
+        let atSecond55 = try date(year: 2026, month: 3, day: 20, hour: h, minute: m, second: 55)
+        #expect(Sun.sunriseElevation(for: atSecond0, latitude: latitude, longitude: longitude, timeZone: timeZone) == .horizon)
+        #expect(Sun.sunriseElevation(for: atSecond15, latitude: latitude, longitude: longitude, timeZone: timeZone) == .horizon)
+        #expect(Sun.sunriseElevation(for: atSecond55, latitude: latitude, longitude: longitude, timeZone: timeZone) == .horizon)
+    }
+
+    @Test("Seconds at boundary: last second before sunrise minute is still .below")
+    func secondsAtSunriseBoundary() throws {
+        let (h, m) = try sunriseComponents(year: 2026, month: 3, day: 20)
+        let lastSecondBefore = try date(year: 2026, month: 3, day: 20, hour: h, minute: m - 1, second: 55)
+        #expect(Sun.sunriseElevation(for: lastSecondBefore, latitude: latitude, longitude: longitude, timeZone: timeZone) == .below)
+
+        let firstSecondAfter = try date(year: 2026, month: 3, day: 20, hour: h, minute: m + 1, second: 15)
+        #expect(Sun.sunriseElevation(for: firstSecondAfter, latitude: latitude, longitude: longitude, timeZone: timeZone) == .above)
+    }
+
+    // MARK: - sunsetElevation
+
+    @Test("Before sunset returns .above")
+    func beforeSunset() throws {
+        let testDate = try date(year: 2026, month: 3, day: 20, hour: 12, minute: 0)
+        #expect(Sun.sunsetElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .above)
+    }
+
+    @Test("After sunset returns .below")
+    func afterSunset() throws {
+        let testDate = try date(year: 2026, month: 3, day: 20, hour: 22, minute: 0)
+        #expect(Sun.sunsetElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .below)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Sun.SunElevation` enum (`.below`, `.horizon`, `.above`) as explicit type for sun state comparison
- Add `Sun.sunriseElevation(for:latitude:longitude:timeZone:)` and `sunsetElevation` as single source of truth for sunrise/sunset comparison at minute granularity
- Refactor `ClockJob` to use `sunriseElevation == .horizon` for emitting `.sunrise` events
- Refactor `Turn.shouldTrigger` to use `sunriseElevation == .below` for `onlyBeforeSunrise` check
- Add 10 unit tests covering edge cases including the spring equinox boundary and second-precision

## Problem

On 2026-03-20 (spring equinox), the `turn-off-at-sunrise` automation fired at 06:29 CET and turned off lights. One minute later, `turn-on-at-0630` with `onlyBeforeSunrise: true` turned them back on.

**Root cause:** The scheduler (`ClockJob`) and the `onlyBeforeSunrise` check (`Turn`) used two independent methods to determine if sunrise had occurred:
1. **Scheduler:** compared calculated sunrise time to current minute → sunrise at 06:29
2. **onlyBeforeSunrise:** checked real-time sun elevation via `Sun.position()` → elevation still slightly negative at 06:30

These disagreed at the minute boundary because sun elevation changes continuously while the scheduler works in discrete minute steps.

## Fix

Both `ClockJob` and `Turn` now call the same `Sun.sunriseElevation()` method, which compares dates at `.minute` granularity. This guarantees they always agree on whether sunrise has passed:

- **Scheduler:** triggers `.sunrise` when `sunriseElevation == .horizon`
- **Turn automation:** only triggers when `sunriseElevation == .below`

## Test plan

- [x] `swift build` passes
- [x] 10 unit tests pass (`SunComparisonTests`), covering:
  - Well before / 1 min before / same minute / 1 min after / well after sunrise
  - Spring equinox edge case (automation at sunrise+1min is blocked)
  - Second-precision tests (seconds within the same minute don't affect result)
  - Sunset comparison (before/after)
- [x] All tests CI-safe (explicit `timeZone` parameter, no `.localOnly` tags)
- [ ] Deploy to server and verify next sunrise cycle