### PR TITLE
Auto-clear window notifications when window closes

### DIFF
--- a/Sources/Controller/App/AppDelegate.swift
+++ b/Sources/Controller/App/AppDelegate.swift
@@ -13,6 +13,7 @@ import Shared
 #if os(iOS)
 import ActivityKit
 import UIKit
+import UserNotifications
 #endif
 
 @MainActor
@@ -43,10 +44,24 @@ extension AppDelegate: UIApplicationDelegate {
     }
 
     public func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult {
-        // This method is called for regular push notifications, but NOT reliably for push-to-start.
-        // According to Apple Developer Forums, this has ~50% success rate for terminated apps.
-        // Token registration is handled via activityUpdates in LiveActivityDependency instead.
         logger.info("didReceiveRemoteNotification called")
+
+        // Background push sent by the server when a window closes.
+        // Remove the matching "window open" notification identified by its threadIdentifier.
+        if let clearId = userInfo["clearNotificationId"] as? String {
+            logger.info("Clearing notification with threadIdentifier: \(clearId)")
+            let center = UNUserNotificationCenter.current()
+            let delivered = await center.deliveredNotifications()
+            let idsToRemove = delivered
+                .filter { $0.request.content.threadIdentifier == clearId }
+                .map(\.request.identifier)
+            if !idsToRemove.isEmpty {
+                center.removeDeliveredNotifications(withIdentifiers: idsToRemove)
+                logger.info("Removed \(idsToRemove.count) notification(s)")
+            }
+            return .newData
+        }
+
         return .noData
     }
 

--- a/Sources/HAApplicationLayer/HomeManager.swift
+++ b/Sources/HAApplicationLayer/HomeManager.swift
@@ -179,6 +179,27 @@ public final class HomeManager: HomeManagable {
         }
     }
 
+    public func sendNotification(title: String, message: String, id: String) async {
+        do {
+            log.debug("Sending notification \(title): \(message) [id: \(id)]")
+            try await notificationSender.sendNotification(title: title, message: message, id: id)
+        } catch {
+            log.critical("Failed to send notification: \(error)")
+            assertionFailure()
+        }
+    }
+
+    public func clearWindowNotification(entityId: EntityId) async {
+        do {
+            let id = entityId.windowNotificationId
+            log.debug("Clearing window notification [id: \(id)]")
+            try await notificationSender.clearNotification(id: id)
+        } catch {
+            log.critical("Failed to clear window notification: \(error)")
+            assertionFailure()
+        }
+    }
+
     public func getWindowStates() async -> [WindowOpenState] {
         await windowManager.getWindowStates()
     }

--- a/Sources/HAApplicationLayer/HomeManager.swift
+++ b/Sources/HAApplicationLayer/HomeManager.swift
@@ -169,16 +169,6 @@ public final class HomeManager: HomeManagable {
         return location
     }
 
-    public func sendNotification(title: String, message: String) async {
-        do {
-            log.debug("Sending notification \(title): \(message)")
-            try await notificationSender.sendNotification(title: title, message: message)
-        } catch {
-            log.critical("Failed to send notification: \(error)")
-            assertionFailure()
-        }
-    }
-
     public func sendNotification(title: String, message: String, id: String) async {
         do {
             log.debug("Sending notification \(title): \(message) [id: \(id)]")

--- a/Sources/HAApplicationLayer/Managers/WindowManager.swift
+++ b/Sources/HAApplicationLayer/Managers/WindowManager.swift
@@ -24,6 +24,11 @@ actor WindowManager {
         Self.logger.info("Window \(action): \(entityId.name) (\(entityId.placeId))")
         windowStateIsOpen[entityId] = newState
 
+        // Clear the delivered push notification for this specific window
+        if newState == nil {
+            try? await notificationSender.clearNotification(id: entityId.windowNotificationId)
+        }
+
         let windowStates = windowStateIsOpen.values.sorted(by: { $0.name < $1.name })
         if !windowStates.isEmpty {
             Self.logger.info("Open windows: \(windowStates.map(\.name).joined(separator: ", "))")

--- a/Sources/HAImplementations/Automations/WindowOpen.swift
+++ b/Sources/HAImplementations/Automations/WindowOpen.swift
@@ -64,7 +64,7 @@ public struct WindowOpen: Automatable {
         log.debug("Start sending notification")
         let message = "\(windowContact.contactSensorId.name) (\(windowContact.contactSensorId.placeId))"
 
-        await hm.sendNotification(title: "🪟 offen", message: message)
+        await hm.sendNotification(title: "🪟 offen", message: message, id: windowContact.contactSensorId.windowNotificationId)
         log.debug("End sending notification")
     }
 }

--- a/Sources/HAModels/EntityId.swift
+++ b/Sources/HAModels/EntityId.swift
@@ -49,6 +49,14 @@ public struct EntityId: Sendable, Hashable, Equatable, Codable, CustomStringConv
 }
 
 extension EntityId {
+    /// Stable identifier used as `apns-collapse-id` and `threadIdentifier` for window-open
+    /// notifications so the server can later clear only the notification for a specific window.
+    public var windowNotificationId: String {
+        "window-\(placeId)-\(name)"
+    }
+}
+
+extension EntityId {
     public struct Query: Sendable, CustomStringConvertible {
         public let placeId: PlaceId
         public let name: String

--- a/Sources/HAModels/HomeManagable.swift
+++ b/Sources/HAModels/HomeManagable.swift
@@ -28,7 +28,6 @@ public protocol HomeManagable: EntityValidator, Sendable {
     func maintenance() async throws
     func deleteStorageEntries(olderThan date: Date) async throws
     func getLocation() async -> Location
-    func sendNotification(title: String, message: String) async
     func sendNotification(title: String, message: String, id: String) async
     func clearWindowNotification(entityId: EntityId) async
     func getWindowStates() async -> [WindowOpenState]

--- a/Sources/HAModels/HomeManagable.swift
+++ b/Sources/HAModels/HomeManagable.swift
@@ -29,6 +29,8 @@ public protocol HomeManagable: EntityValidator, Sendable {
     func deleteStorageEntries(olderThan date: Date) async throws
     func getLocation() async -> Location
     func sendNotification(title: String, message: String) async
+    func sendNotification(title: String, message: String, id: String) async
+    func clearWindowNotification(entityId: EntityId) async
     func getWindowStates() async -> [WindowOpenState]
     func setWindowOpenState(entityId: EntityId, to state: WindowOpenState?) async
     func getActionLog(limit: Int?) async -> [ActionLogItem]

--- a/Sources/HAModels/NotificationSender.swift
+++ b/Sources/HAModels/NotificationSender.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 public protocol NotificationSender: Sendable {
-    func sendNotification(title: String, message: String) async throws
-
     /// Sends an alert notification tagged with a stable `id` used as `apns-collapse-id`
     /// and `threadIdentifier`, allowing the notification to be coalesced and later cleared
     /// individually via ``clearNotification(id:)``.
@@ -24,11 +22,6 @@ public protocol NotificationSender: Sendable {
 }
 
 extension NotificationSender {
-    /// Default: falls back to the untagged overload.
-    public func sendNotification(title: String, message: String, id: String) async throws {
-        try await sendNotification(title: title, message: message)
-    }
-
     /// Default: no-op for conformances that don't support background push.
     public func clearNotification(id: String) async throws {}
 }

--- a/Sources/HAModels/NotificationSender.swift
+++ b/Sources/HAModels/NotificationSender.swift
@@ -20,8 +20,3 @@ public protocol NotificationSender: Sendable {
     func startOrUpdateLiveActivity<ContentState: Encodable & Sendable>(contentState: ContentState, activityName: String) async
     func endAllLiveActivities(ofActivityType activityType: String) async
 }
-
-extension NotificationSender {
-    /// Default: no-op for conformances that don't support background push.
-    public func clearNotification(id: String) async throws {}
-}

--- a/Sources/HAModels/NotificationSender.swift
+++ b/Sources/HAModels/NotificationSender.swift
@@ -9,6 +9,26 @@ import Foundation
 
 public protocol NotificationSender: Sendable {
     func sendNotification(title: String, message: String) async throws
+
+    /// Sends an alert notification tagged with a stable `id` used as `apns-collapse-id`
+    /// and `threadIdentifier`, allowing the notification to be coalesced and later cleared
+    /// individually via ``clearNotification(id:)``.
+    func sendNotification(title: String, message: String, id: String) async throws
+
+    /// Sends a `content-available` background push so the client can remove a previously
+    /// delivered notification identified by `id` (matched via `threadIdentifier`).
+    func clearNotification(id: String) async throws
+
     func startOrUpdateLiveActivity<ContentState: Encodable & Sendable>(contentState: ContentState, activityName: String) async
     func endAllLiveActivities(ofActivityType activityType: String) async
+}
+
+extension NotificationSender {
+    /// Default: falls back to the untagged overload.
+    public func sendNotification(title: String, message: String, id: String) async throws {
+        try await sendNotification(title: title, message: message)
+    }
+
+    /// Default: no-op for conformances that don't support background push.
+    public func clearNotification(id: String) async throws {}
 }

--- a/Sources/Server/Controllers/PushNotifcationService.swift
+++ b/Sources/Server/Controllers/PushNotifcationService.swift
@@ -30,10 +30,6 @@ actor PushNotifcationService: NotificationSender {
         self.notificationTopic = notificationTopic
     }
 
-    func sendNotification(title: String, message: String) async throws {
-        try await sendAlert(title: title, message: message, id: nil)
-    }
-
     func sendNotification(title: String, message: String, id: String) async throws {
         try await sendAlert(title: title, message: message, id: id)
     }

--- a/Sources/Server/Controllers/PushNotifcationService.swift
+++ b/Sources/Server/Controllers/PushNotifcationService.swift
@@ -11,6 +11,12 @@ import Foundation
 import HAModels
 import VaporAPNS
 
+/// Payload for `content-available` background pushes that tell the client
+/// to remove a previously delivered notification matched by `threadIdentifier`.
+private struct ClearNotificationPayload: Encodable, Sendable {
+    let clearNotificationId: String
+}
+
 actor PushNotifcationService: NotificationSender {
     private static let logger = Logger(label: "PushNotifcationService")
 
@@ -25,18 +31,60 @@ actor PushNotifcationService: NotificationSender {
     }
 
     func sendNotification(title: String, message: String) async throws {
+        try await sendAlert(title: title, message: message, id: nil)
+    }
+
+    func sendNotification(title: String, message: String, id: String) async throws {
+        try await sendAlert(title: title, message: message, id: id)
+    }
+
+    func clearNotification(id: String) async throws {
+        let deviceTokens = try await DeviceToken
+            .query(on: database)
+            .filter(\.$tokenType == "pushNotification")
+            .all()
+
+        let payload = ClearNotificationPayload(clearNotificationId: id)
+        let notification = APNSBackgroundNotification(
+            expiration: .immediately,
+            topic: notificationTopic,
+            payload: payload
+        )
+
+        for deviceToken in deviceTokens {
+            do {
+                try await apnsClient.sendBackgroundNotification(notification, deviceToken: deviceToken.tokenString)
+            } catch {
+                Self.logger.critical(
+                    "Failed to send clear notification to \(deviceToken.deviceName): \(error.localizedDescription)"
+                )
+                try? await DeviceToken.query(on: database)
+                    .filter(\.$tokenString == deviceToken.tokenString)
+                    .delete()
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func sendAlert(title: String, message: String, id: String?) async throws {
         let deviceTokens =
             try await DeviceToken
             .query(on: database)
             .filter(\.$tokenType == "pushNotification")
             .all()
 
-        let notification = APNSAlertNotification(
+        var notification = APNSAlertNotification(
             alert: .init(title: .raw(title), body: .raw(message)),
             expiration: .none,
             priority: .immediately,
             topic: notificationTopic
         )
+
+        if let id {
+            notification.collapseID = id
+            notification.threadID = id
+        }
 
         for deviceToken in deviceTokens {
             do {

--- a/Tests/HomeAutomationKitTests/MockHomeAdapter.swift
+++ b/Tests/HomeAutomationKitTests/MockHomeAdapter.swift
@@ -134,8 +134,11 @@ final class MockHomeAdapter: @unchecked Sendable, HomeManagable {
         return Location(latitude: 0, longitude: 0)
     }
 
-    func sendNotification(title: String, message: String) async {
-    }
+    func sendNotification(title: String, message: String) async {}
+
+    func sendNotification(title: String, message: String, id: String) async {}
+
+    func clearWindowNotification(entityId: EntityId) async {}
 
     func getWindowStates() async -> [WindowOpenState] {
         return []

--- a/Tests/HomeAutomationKitTests/MockHomeAdapter.swift
+++ b/Tests/HomeAutomationKitTests/MockHomeAdapter.swift
@@ -134,8 +134,6 @@ final class MockHomeAdapter: @unchecked Sendable, HomeManagable {
         return Location(latitude: 0, longitude: 0)
     }
 
-    func sendNotification(title: String, message: String) async {}
-
     func sendNotification(title: String, message: String, id: String) async {}
 
     func clearWindowNotification(entityId: EntityId) async {}

--- a/Tests/HomeAutomationKitTests/MockNotificationSender.swift
+++ b/Tests/HomeAutomationKitTests/MockNotificationSender.swift
@@ -9,8 +9,6 @@ import Foundation
 import HAModels
 
 final class MockNotificationSender: NotificationSender, @unchecked Sendable {
-    func sendNotification(title: String, message: String) async throws {}
-
     func sendNotification(title: String, message: String, id: String) async throws {}
 
     func clearNotification(id: String) async throws {}

--- a/Tests/HomeAutomationKitTests/MockNotificationSender.swift
+++ b/Tests/HomeAutomationKitTests/MockNotificationSender.swift
@@ -9,15 +9,13 @@ import Foundation
 import HAModels
 
 final class MockNotificationSender: NotificationSender, @unchecked Sendable {
-    func sendNotification(title: String, message: String) async throws {
-        // Mock implementation - does nothing
-    }
+    func sendNotification(title: String, message: String) async throws {}
 
-    func startOrUpdateLiveActivity<ContentState: Encodable & Sendable>(contentState: ContentState, activityName: String) async {
-        // Mock implementation - does nothing
-    }
+    func sendNotification(title: String, message: String, id: String) async throws {}
 
-    func endAllLiveActivities(ofActivityType activityType: String) async {
-        // Mock implementation - does nothing
-    }
+    func clearNotification(id: String) async throws {}
+
+    func startOrUpdateLiveActivity<ContentState: Encodable & Sendable>(contentState: ContentState, activityName: String) async {}
+
+    func endAllLiveActivities(ofActivityType activityType: String) async {}
 }


### PR DESCRIPTION
## Summary

Closes #155

- Window-open notifications (`🪟 offen`) now carry a stable `collapseID` and `threadID` per entity (`EntityId.windowNotificationId`), enabling per-window coalescing and targeted removal
- When a window closes, the server sends a `content-available` background push with the notification ID so the client can remove only that specific notification
- Existing `removeAllDeliveredNotifications` on app activation is kept as fallback for cases where the background push isn't delivered

## Changes

| Layer | File | Change |
|-------|------|--------|
| Models | `EntityId.swift` | Added `windowNotificationId` computed property |
| Models | `NotificationSender.swift` | Added `sendNotification(title:message:id:)` and `clearNotification(id:)` with default implementations |
| Models | `HomeManagable.swift` | Added protocol requirements for tagged notifications |
| Server | `PushNotifcationService.swift` | Implemented tagged alert sending (collapseID + threadID) and background push clearing |
| App Layer | `HomeManager.swift` | Forward new notification methods |
| App Layer | `WindowManager.swift` | Trigger `clearNotification` when window closes |
| Automations | `WindowOpen.swift` | Pass `windowNotificationId` when sending notification |
| Controller | `AppDelegate.swift` | Handle `clearNotificationId` background push by matching `threadIdentifier` |
| Tests | `MockHomeAdapter.swift`, `MockNotificationSender.swift` | Added stubs for new protocol methods |

## Test plan

- [ ] `swift build` passes
- [ ] `swift test` passes
- [ ] Manual: Open window → wait 15 min → close window → notification disappears without opening app
- [ ] Manual: Open 2 windows → close 1 → only that window's notification removed
- [ ] Manual: Open window → close before 15 min → no stale notification appears
- [ ] Fallback: Notifications still cleared when app becomes active