### PR TITLE
Reclassify log levels, add CRITICAL push notifications, and improve observability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN swift package resolve
 # Copy entire repo into container
 COPY . .
 
+# Capture git commit hash for runtime logging
+RUN git rev-parse --short HEAD > /tmp/git-commit 2>/dev/null || echo "unknown" > /tmp/git-commit
+
 # Build the application, with optimizations, with static linking, and using jemalloc
 # N.B.: The static version of jemalloc is incompatible with the static Swift runtime.
 RUN swift build -c release \
@@ -74,6 +77,9 @@ WORKDIR /app
 
 # Copy built executable and any staged resources from builder
 COPY --from=build --chown=vapor:vapor /staging /app
+
+# Copy git commit hash for startup logging
+COPY --from=build --chown=vapor:vapor /tmp/git-commit /app/git-commit
 
 # Provide configuration needed by the built-in crash reporter and some sensible default behaviors.
 ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no,swift-backtrace=./swift-backtrace-static

--- a/Sources/Adapter/DistributedActors/HomeKitCommandReceiver.swift
+++ b/Sources/Adapter/DistributedActors/HomeKitCommandReceiver.swift
@@ -48,7 +48,7 @@ public distributed actor HomeKitCommandReceiver {
         do {
             try await adapter.perform(action)
         } catch {
-            log.critical("perform(_:) — failed action '\(action)': \(error)")
+            log.error("perform(_:) — failed action '\(action)': \(error)")
             throw error
         }
     }
@@ -62,7 +62,7 @@ public distributed actor HomeKitCommandReceiver {
             log.info("trigger(scene:) — completed '\(sceneName)' in \(duration)")
         } catch {
             let duration = start.duration(to: .now)
-            log.critical("trigger(scene:) — failed '\(sceneName)' after \(duration): \(error)")
+            log.error("trigger(scene:) — failed '\(sceneName)' after \(duration): \(error)")
             throw error
         }
     }

--- a/Sources/Adapter/Extensions/HMCharacteristic.swift
+++ b/Sources/Adapter/Extensions/HMCharacteristic.swift
@@ -82,7 +82,7 @@ extension HMCharacteristic: @retroactive Comparable {
                                      valveOpen: valveOpen)
         } catch {
             // this might occur when e.g. the IKEA hub or a device is not available
-            homeKitLogger.critical("Error while getting characteristic data - \(self.service?.accessory?.room?.name ?? "")@\(self.service?.accessory?.name ?? "") - \(self)\n\(error)")
+            homeKitLogger.warning("Error while getting characteristic data - \(self.service?.accessory?.room?.name ?? "")@\(self.service?.accessory?.name ?? "") - \(self)\n\(error)")
             return nil
         }
     }

--- a/Sources/Adapter/HomeKitAdapter+Delegates.swift
+++ b/Sources/Adapter/HomeKitAdapter+Delegates.swift
@@ -58,7 +58,7 @@ extension HomeKitAdapter {
             do {
                 try await home.executeActionSet(actionSet)
             } catch {
-                log.critical("Failed to execute action set '\(actionSet.name)': \(error)")
+                log.error("Failed to execute action set '\(actionSet.name)': \(error)")
                 throw error
             }
         }
@@ -96,7 +96,7 @@ extension HomeKitAdapter {
                     }
                 } catch {
                     subscriptionErrors += 1
-                    log.critical("Failed to enable notification on accessory \(accessory.name) - error \(error)")
+                    log.error("Failed to enable notification on accessory \(accessory.name) - error \(error)")
 
                     #if DEBUG
                     // do not jump to the assertion when there error is:

--- a/Sources/Adapter/HomeKitAdapter.swift
+++ b/Sources/Adapter/HomeKitAdapter.swift
@@ -60,7 +60,7 @@ public final class HomeKitAdapter: HomeKitAdapterable {
         let filteredCharacteristics = characteristics.filter({ $0.entityId == entity })
         guard filteredCharacteristics.count == 1 else {
             log.debug("Found: \(filteredCharacteristics)")
-            log.critical("Validation: Could not find entity \(entity)")
+            log.error("Validation: Could not find entity \(entity)")
             assertionFailure()
             throw OptionalError.notFound
         }
@@ -71,7 +71,7 @@ public final class HomeKitAdapter: HomeKitAdapterable {
         let filteredCharacteristics = characteristics.filter({ $0.entityId == action.entityId })
         guard filteredCharacteristics.count == 1,
               let characteristic = filteredCharacteristics.first else {
-            log.critical("Failed to get characteristic")
+            log.error("Failed to get characteristic")
             assertionFailure()
             return
         }
@@ -118,7 +118,7 @@ public final class HomeKitAdapter: HomeKitAdapterable {
             newValue = NSNumber(value: HMCharacteristicValueLockMechanismState.secured.rawValue)
         case .addEntityToScene(_, sceneName: let sceneName, let action):
             guard let home = characteristic.service?.accessory?.home else {
-                log.critical("Failed to get home for characteristic")
+                log.error("Failed to get home for characteristic")
                 assertionFailure()
                 return
             }
@@ -128,7 +128,7 @@ public final class HomeKitAdapter: HomeKitAdapterable {
                 try await home.addActionSet(named: sceneName)
             }
             guard let scene = home.actionSets.first(where: { $0.name == sceneName }) else {
-                log.critical("Could not find scene named \(sceneName)")
+                log.error("Could not find scene named \(sceneName)")
                 assertionFailure()
                 return
             }
@@ -173,7 +173,7 @@ public final class HomeKitAdapter: HomeKitAdapterable {
         do {
             try await homeKitHomeManager.trigger(scene: sceneName)
         } catch {
-            log.critical("Failed to trigger scene '\(sceneName)': \(error)")
+            log.error("Failed to trigger scene '\(sceneName)': \(error)")
             throw error
         }
     }

--- a/Sources/Controller/Features/LogViewerView.swift
+++ b/Sources/Controller/Features/LogViewerView.swift
@@ -79,13 +79,15 @@ struct LogViewerView: View {
 
     @ViewBuilder
     private func logRow(_ entry: LogEntry) -> some View {
+        let isCritical = entry.level.lowercased() == "critical"
+
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(entry.level.uppercased())
-                    .font(.caption2.bold())
+                    .font(isCritical ? .caption.bold() : .caption2.bold())
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(levelColor(entry.level).opacity(0.2))
+                    .background(levelColor(entry.level).opacity(isCritical ? 0.4 : 0.2))
                     .foregroundStyle(levelColor(entry.level))
                     .clipShape(Capsule())
 
@@ -102,15 +104,16 @@ struct LogViewerView: View {
 
             Text(entry.message)
                 .font(.caption)
-                .lineLimit(3)
+                .lineLimit(isCritical ? 10 : 3)
         }
+        .listRowBackground(isCritical ? Color.red.opacity(0.08) : nil)
     }
 
     private func levelColor(_ level: String) -> Color {
         switch level.lowercased() {
         case "debug", "trace": .gray
         case "info", "notice": .blue
-        case "warning": .orange
+        case "warning": .yellow
         case "error": .orange
         case "critical": .red
         default: .secondary
@@ -122,8 +125,9 @@ struct LogViewerView: View {
     NavigationStack {
         LogViewerView(
             entries: [
-                LogEntry(timestamp: Date(), level: "info", label: "AppFeature", message: "Scene phase: inactive -> active"),
-                LogEntry(timestamp: Date().addingTimeInterval(-5), level: "error", label: "AppFeature", message: "Failed to register push token"),
+                LogEntry(timestamp: Date(), level: "critical", label: "HomeManager", message: "Failed to persist entity item Error(connectionReset)"),
+                LogEntry(timestamp: Date().addingTimeInterval(-5), level: "info", label: "AppFeature", message: "Scene phase: inactive -> active"),
+                LogEntry(timestamp: Date().addingTimeInterval(-10), level: "error", label: "AppFeature", message: "Failed to register push token"),
                 LogEntry(timestamp: Date().addingTimeInterval(-60), level: "debug", label: "LiveActivity", message: "hasActiveActivities: 1 active"),
             ],
             isLoading: false,

--- a/Sources/HAApplicationLayer/AutomationService.swift
+++ b/Sources/HAApplicationLayer/AutomationService.swift
@@ -38,7 +38,7 @@ public actor AutomationService {
                             } catch is CancellationError {
                                 // do not throw anything when an automation was cancelled
                             } catch {
-                                self.log.critical("Automation failed with error - \(error)")
+                                self.log.error("Automation failed with error - \(error)")
                             }
 
                             // cancel the current task after completion to get correct results of getActiveAutomationNames
@@ -48,7 +48,7 @@ public actor AutomationService {
                         }
                         await self.set(task: task, with: automation.name)
                     } catch {
-                        self.log.critical("Automation (e.g. shouldTrigger failed with error - \(error)")
+                        self.log.error("Automation shouldTrigger failed with error - \(error)")
                     }
                 }
             }

--- a/Sources/HAApplicationLayer/HomeManager.swift
+++ b/Sources/HAApplicationLayer/HomeManager.swift
@@ -106,9 +106,9 @@ public final class HomeManager: HomeManagable {
             let entityId = action.entityId
 
             if let entity = try? await getCurrentEntity(with: entityId) {
-                log.critical("(\(entityId)) entity \(entity)")
+                log.error("(\(entityId)) entity \(entity)")
             }
-            log.critical("(\(entityId)) Failed to perform action [\(action), addToFaliedActions: \(addToFaliedActions)]\n\(error)")
+            log.error("(\(entityId)) Failed to perform action [\(action), addToFaliedActions: \(addToFaliedActions)]\n\(error)")
 
             if addToFaliedActions {
                 failedActions[entityId] = action
@@ -125,7 +125,7 @@ public final class HomeManager: HomeManagable {
             log.info("Triggering scene '\(sceneName)' — completed in \(duration)")
         } catch {
             let duration = start.duration(to: .now)
-            log.critical("Failed to trigger scene '\(sceneName)' after \(duration)\n\(error)")
+            log.error("Failed to trigger scene '\(sceneName)' after \(duration)\n\(error)")
         }
     }
 
@@ -150,7 +150,6 @@ public final class HomeManager: HomeManagable {
                 }
             } catch {
                 self.log.critical("Failed to persist entity item \(error)")
-                assertionFailure()
             }
         }
     }
@@ -174,8 +173,7 @@ public final class HomeManager: HomeManagable {
             log.debug("Sending notification \(title): \(message) [id: \(id)]")
             try await notificationSender.sendNotification(title: title, message: message, id: id)
         } catch {
-            log.critical("Failed to send notification: \(error)")
-            assertionFailure()
+            log.warning("Failed to send notification: \(error)")
         }
     }
 
@@ -185,8 +183,7 @@ public final class HomeManager: HomeManagable {
             log.debug("Clearing window notification [id: \(id)]")
             try await notificationSender.clearNotification(id: id)
         } catch {
-            log.critical("Failed to clear window notification: \(error)")
-            assertionFailure()
+            log.warning("Failed to clear window notification: \(error)")
         }
     }
 

--- a/Sources/HAImplementations/Automations/MotionAtNight.swift
+++ b/Sources/HAImplementations/Automations/MotionAtNight.swift
@@ -58,7 +58,7 @@ public struct MotionAtNight: Automatable {
             do {
                 return try await motionSensor.motionDetectedState(with: hm)
             } catch {
-                log.critical("Failed to get motion sensor data - \(error)")
+                log.warning("Failed to get motion sensor data - \(error)")
                 return false
             }
         }).contains { $0 }
@@ -67,7 +67,7 @@ public struct MotionAtNight: Automatable {
         do {
             illuminance = try await lightSensor.illuminanceState(with: hm)
         } catch {
-            log.critical("Failed to get illuminance state - \(error)")
+            log.warning("Failed to get illuminance state - \(error)")
         }
         guard let illuminance else { return false }
 
@@ -81,7 +81,7 @@ public struct MotionAtNight: Automatable {
             do {
                 return try await windowSensor.isContactOpen(with: hm)
             } catch {
-                log.critical("Failed to get contact sensor - \(error)")
+                log.warning("Failed to get contact sensor - \(error)")
                 return false
             }
         }).contains { $0 }

--- a/Sources/HAImplementations/TibberService.swift
+++ b/Sources/HAImplementations/TibberService.swift
@@ -35,12 +35,25 @@ public actor TibberService: Log {
 
         if let priceCache,
             Calendar.current.isDate(priceCache.0, inSameDayAs: date) {
+            log.debug("Using cached Tibber prices from \(priceCache.0)")
             return priceCache.1
         }
 
-        let response = try await tibber.priceInfoToday()
+        log.info("Fetching Tibber prices (cache miss or expired)")
+        let start = ContinuousClock.now
+        let response: PriceInfoToday
+        do {
+            response = try await tibber.priceInfoToday()
+        } catch {
+            let duration = start.duration(to: .now)
+            log.error("Tibber API call failed after \(duration): \(error)")
+            throw error
+        }
+        let duration = start.duration(to: .now)
+        log.info("Tibber API responded in \(duration) with \(response.homes.count) home(s)")
+
         guard let home = response.homes.first else {
-            log.critical("Failed to get home")
+            log.error("Failed to get home - Tibber API returned empty homes array")
             return []
         }
 
@@ -57,6 +70,7 @@ public actor TibberService: Log {
             return TodayPrice(time: start...end, price: price.total)
         }
 
+        log.info("Fetched \(prices.count) price entries for today")
         priceCache = (date, prices)
         return prices
     }
@@ -81,11 +95,15 @@ public actor TibberService: Log {
     }
 
     public func sendNotification(title: String, message: String) async {
-        log.info("Sending notification \(title) \(message)")
+        log.info("Sending Tibber notification: \(title)")
+        let start = ContinuousClock.now
         do {
             _ = try await tibber.sendPushNotification(title: title, message: message)
+            let duration = start.duration(to: .now)
+            log.info("Tibber notification sent in \(duration)")
         } catch {
-            log.critical("Failed to send notification \(error.localizedDescription)")
+            let duration = start.duration(to: .now)
+            log.error("Failed to send Tibber notification after \(duration): \(error)")
         }
     }
 }

--- a/Sources/Server/Controllers/OpenAPIController.swift
+++ b/Sources/Server/Controllers/OpenAPIController.swift
@@ -90,7 +90,7 @@ struct OpenAPIController: APIProtocol {
 
         case .liveActivityUpdate:
             guard let activityType = token.activityType else {
-                request.logger.critical("Token of type liveActivityUpdate must contain activityType")
+                request.logger.error("Token of type liveActivityUpdate must contain activityType")
                 return .internalServerError
             }
 

--- a/Sources/Server/Controllers/PushNotifcationService.swift
+++ b/Sources/Server/Controllers/PushNotifcationService.swift
@@ -51,12 +51,16 @@ actor PushNotifcationService: NotificationSender {
             do {
                 try await apnsClient.sendBackgroundNotification(notification, deviceToken: deviceToken.tokenString)
             } catch {
-                Self.logger.critical(
+                Self.logger.warning(
                     "Failed to send clear notification to \(deviceToken.deviceName): \(error.localizedDescription)"
                 )
-                try? await DeviceToken.query(on: database)
-                    .filter(\.$tokenString == deviceToken.tokenString)
-                    .delete()
+                do {
+                    try await DeviceToken.query(on: database)
+                        .filter(\.$tokenString == deviceToken.tokenString)
+                        .delete()
+                } catch {
+                    Self.logger.error("[clearNotification] Failed to delete invalid device token for \(deviceToken.deviceName): \(error)")
+                }
             }
         }
     }
@@ -86,12 +90,16 @@ actor PushNotifcationService: NotificationSender {
             do {
                 try await apnsClient.sendAlertNotification(notification, deviceToken: deviceToken.tokenString)
             } catch {
-                Self.logger.critical(
+                Self.logger.warning(
                     "Failed to send push notification to \(deviceToken.deviceName) [\(deviceToken.tokenType)]: \(error.localizedDescription)"
                 )
-                try? await DeviceToken.query(on: database)
-                    .filter(\.$tokenString == deviceToken.tokenString)
-                    .delete()
+                do {
+                    try await DeviceToken.query(on: database)
+                        .filter(\.$tokenString == deviceToken.tokenString)
+                        .delete()
+                } catch {
+                    Self.logger.error("[sendAlert] Failed to delete invalid device token for \(deviceToken.deviceName): \(error)")
+                }
             }
         }
     }
@@ -191,11 +199,15 @@ actor PushNotifcationService: NotificationSender {
                         // 3. The app re-registers the new token with the server
                         // 4. If the app was not woken (force-quit / iOS budget), the token is
                         //    re-registered when the user next opens the app
-                        try? await DeviceToken.query(on: database)
-                            .filter(\.$tokenString == startToken.tokenString)
-                            .delete()
+                        do {
+                            try await DeviceToken.query(on: database)
+                                .filter(\.$tokenString == startToken.tokenString)
+                                .delete()
+                        } catch {
+                            Self.logger.error("[startOrUpdateLiveActivity] Failed to delete start token for \(startToken.deviceName): \(error)")
+                        }
                     } else {
-                        assertionFailure("Should find at least one start token")
+                        Self.logger.error("[startOrUpdateLiveActivity] No start or update token found for device")
                     }
                 } catch is CancellationError {
                     // CancellationError is expected when rapid window state changes occur.
@@ -207,23 +219,26 @@ actor PushNotifcationService: NotificationSender {
                 } catch {
                     if let apnsError = error as? APNSError,
                         let id = apnsError.apnsUniqueID {
-                        Self.logger.critical(
+                        Self.logger.error(
                             "[startOrUpdateLiveActivity] Error sending push notification apnsUniqueID: \(id.uuidString)"
                         )
                     }
-                    Self.logger.critical(
+                    Self.logger.warning(
                         "[startOrUpdateLiveActivity] Failed to send live activity push notification to \(usedToken?.deviceName ?? "") [\(usedToken?.tokenType ?? "")]: \(error.localizedDescription)"
                     )
-                    try? await DeviceToken.query(on: database)
-                        .filter(\.$tokenString == usedToken?.tokenString ?? "")
-                        .delete()
+                    do {
+                        try await DeviceToken.query(on: database)
+                            .filter(\.$tokenString == usedToken?.tokenString ?? "")
+                            .delete()
+                    } catch {
+                        Self.logger.error("[startOrUpdateLiveActivity] Failed to delete token after error for \(usedToken?.deviceName ?? ""): \(error)")
+                    }
                 }
             }
 
         } catch {
             Self.logger.critical(
                 "Failed to fetch push devices in startOrUpdateOpenWindowActivities: \(error)")
-            assertionFailure()
         }
     }
 
@@ -256,26 +271,29 @@ actor PushNotifcationService: NotificationSender {
                             .filter(\.$tokenString == deviceToken.tokenString)
                             .delete()
                     } catch {
-                        Self.logger.critical("Failed to delete device token: \(error.localizedDescription)")
+                        Self.logger.error("Failed to delete device token: \(error.localizedDescription)")
                     }
                 } catch {
                     if let apnsError = error as? APNSError,
                         let id = apnsError.apnsUniqueID {
-                        Self.logger.critical(
+                        Self.logger.error(
                             "[endAllLiveActivities] Error sending push notification apnsUniqueID: \(id.uuidString)"
                         )
                     }
-                    Self.logger.critical(
+                    Self.logger.warning(
                         "[endAllLiveActivities] Failed to send live activity push notification to \(deviceToken.deviceName) [\(deviceToken.tokenType)]: \(error.localizedDescription)"
                     )
-                    try? await DeviceToken.query(on: database)
-                        .filter(\.$tokenString == deviceToken.tokenString)
-                        .delete()
+                    do {
+                        try await DeviceToken.query(on: database)
+                            .filter(\.$tokenString == deviceToken.tokenString)
+                            .delete()
+                    } catch {
+                        Self.logger.error("[endAllLiveActivities] Failed to delete token for \(deviceToken.deviceName): \(error)")
+                    }
                 }
             }
         } catch {
             Self.logger.critical("Failed to fetch push devices: \(error)")
-            assertionFailure()
         }
 
         do {
@@ -284,8 +302,7 @@ actor PushNotifcationService: NotificationSender {
                 .filter(\.$activityType == activityType)
                 .delete()
         } catch {
-            Self.logger.critical("Failed to delete old token")
-            assertionFailure()
+            Self.logger.error("Failed to delete old token: \(error)")
         }
     }
 }

--- a/Sources/Server/CriticalLogNotifier.swift
+++ b/Sources/Server/CriticalLogNotifier.swift
@@ -1,0 +1,88 @@
+//
+//  CriticalLogNotifier.swift
+//  HomeAutomation
+//
+//  Sends push notifications when CRITICAL-level log events occur.
+//  Throttles to at most one notification per label per hour.
+//
+
+import Foundation
+import HAModels
+import Logging
+
+/// Sends a push notification when a CRITICAL log event is recorded.
+///
+/// Register with ``configure(notificationSender:)`` after the push
+/// infrastructure is ready. Until then, critical events are silently skipped.
+actor CriticalLogNotifier {
+    static let shared = CriticalLogNotifier()
+
+    private var notificationSender: (any NotificationSender)?
+    private var lastNotificationTime: [String: Date] = [:]
+    private let throttleInterval: TimeInterval = 3600
+
+    func configure(notificationSender: any NotificationSender) {
+        self.notificationSender = notificationSender
+    }
+
+    func notify(label: String, message: String) async {
+        guard let sender = notificationSender else { return }
+
+        let now = Date()
+        if let lastTime = lastNotificationTime[label],
+           now.timeIntervalSince(lastTime) < throttleInterval {
+            return
+        }
+        lastNotificationTime[label] = now
+
+        do {
+            try await sender.sendNotification(
+                title: "Critical: \(label)",
+                message: String(message.prefix(256)),
+                id: "critical-\(label)"
+            )
+        } catch {
+            // Avoid recursion: do not log at .critical here
+        }
+    }
+}
+
+/// LogHandler wrapper that forwards all calls to an underlying handler
+/// and additionally triggers a push notification on `.critical` events.
+struct CriticalNotifyingLogHandler: LogHandler {
+    private var underlying: any LogHandler
+    private let label: String
+
+    var logLevel: Logger.Level {
+        get { underlying.logLevel }
+        set { underlying.logLevel = newValue }
+    }
+
+    var metadata: Logger.Metadata {
+        get { underlying.metadata }
+        set { underlying.metadata = newValue }
+    }
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { underlying[metadataKey: key] }
+        set { underlying[metadataKey: key] = newValue }
+    }
+
+    init(label: String, underlying: any LogHandler) {
+        self.label = label
+        self.underlying = underlying
+    }
+
+    func log(event: LogEvent) {
+        underlying.log(event: event)
+
+        if event.level == .critical {
+            Task {
+                await CriticalLogNotifier.shared.notify(
+                    label: label,
+                    message: "\(event.message)"
+                )
+            }
+        }
+    }
+}

--- a/Sources/Server/configure.swift
+++ b/Sources/Server/configure.swift
@@ -26,6 +26,8 @@ public func configure(_ app: Application) async throws {
         setenv("TZ", timeZoneString, 1)
         CFTimeZoneResetSystem()
     }
+    let gitCommit = (try? String(contentsOfFile: "git-commit", encoding: .utf8))?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "unknown"
+    app.logger.info("Git commit: \(gitCommit)")
     app.logger.info("Using timezone: \(TimeZone.current.description)")
     app.logger.info("Using environment: \(app.environment.name) (isRelease: \(app.environment.isRelease))")
 
@@ -211,6 +213,9 @@ public func configure(_ app: Application) async throws {
     let notificationSender = PushNotifcationService(database: app.db,
                                                     apnsClient: apnsClient,
                                                     notificationTopic: notificationTopic)
+
+    // Wire up push notifications for CRITICAL log events
+    await CriticalLogNotifier.shared.configure(notificationSender: notificationSender)
 
     let actionLogManager = ActionLogManager()
     let homeManager = await HomeManager(getAdapter: {

--- a/Sources/Server/entrypoint.swift
+++ b/Sources/Server/entrypoint.swift
@@ -6,7 +6,13 @@ import Vapor
 enum Entrypoint {
     static func main() async throws {
         var env = try Environment.detect()
-        try LoggingSystem.bootstrap(from: &env)
+
+        // Custom bootstrap: wraps each handler with CriticalNotifyingLogHandler
+        // so that CRITICAL log events trigger push notifications.
+        LoggingSystem.bootstrap { label in
+            let underlying = StreamLogHandler.standardOutput(label: label)
+            return CriticalNotifyingLogHandler(label: label, underlying: underlying)
+        }
 //        try LoggingSystem.bootstrap(from: &env) { level in
 //            return { label in
 //                var logger = StreamLogHandler.standardOutput(label: label)


### PR DESCRIPTION
## Summary

Closes #159

- **Reclassify ~25 log calls** from `.critical` to `.error`/`.warning` per the severity audit in the issue — only 6 genuinely critical calls remain (DB failures, config missing, system down, auth failure)
- **Add `CriticalNotifyingLogHandler`** — wraps the logging pipeline to send push notifications on CRITICAL events, throttled to max 1 per label per hour
- **Improve LogViewerView** — CRITICAL entries now have a red background tint, larger badge, and expanded message (10 lines vs 3), plus warning is now yellow (was orange like error)
- **Replace silent `try?`** in `PushNotifcationService` with `do/catch` + `.error` logging (5 locations)
- **Log git commit hash** on server startup — captured during Docker build via `git rev-parse --short HEAD`, read from file at startup
- **Add Tibber API debugging** — request timing, cache state, and response details logged to help diagnose 504 errors
- **Remove `assertionFailure()` calls** that masked issues in debug but did nothing in release

### Remaining CRITICAL log calls (verified as genuinely critical)
| Location | Reason |
|----------|--------|
| `TibberService` | Missing API key env var — automation can't init |
| `PushNotifcationService` (x2) | DB fetch failure — can't send any notifications |
| `HomeManager` | Entity persistence failure — data loss risk |
| `AppDelegate` | Push registration failure — app can't receive notifications |
| `HomeKitAdapter+Delegates` | HomeKit not authorized — entire adapter non-functional |
| `CustomActorSystem` | Connection lost after grace period — system down |

## Test plan
- [ ] `swift build` passes (verified locally)
- [ ] Verify CRITICAL log entry styling in iOS log viewer
- [ ] Deploy Docker image and verify git commit appears in startup logs
- [ ] Trigger a CRITICAL event and verify push notification is received
- [ ] Verify throttling: second CRITICAL from same label within 1h does NOT send another notification
- [ ] Verify Tibber API logs show timing info on next run