### PR TITLE
Fix Docker build: add FoundationNetworking to TibberSwift

### DIFF
--- a/Apps/FlowKitAdapter/FlowKit Adapter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/FlowKitAdapter/FlowKit Adapter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -384,8 +384,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/juliankahnert/TibberSwift.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "d3c4ac0663a4ed5225ea726e88513fb2c1bf7a39"
+        "branch" : "fix/linux-foundation-networking",
+        "revision" : "eaa419ade64d0c3a6503496803a9eaca9f072040"
       }
     },
     {

--- a/Apps/FlowKitController/FlowKit Controller.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/FlowKitController/FlowKit Controller.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -384,8 +384,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/juliankahnert/TibberSwift.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "d3c4ac0663a4ed5225ea726e88513fb2c1bf7a39"
+        "branch" : "fix/linux-foundation-networking",
+        "revision" : "eaa419ade64d0c3a6503496803a9eaca9f072040"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f5eace316f2e9a12cb777d9c17f1dab487f073c20b2a09291723ff7a9a956777",
+  "originHash" : "07d69e813cda2012933c5691387de25376970d4c92e721e4a98746356caa912c",
   "pins" : [
     {
       "identity" : "apns",
@@ -526,10 +526,10 @@
     {
       "identity" : "tibberswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ppeelen/TibberSwift.git",
+      "location" : "https://github.com/juliankahnert/TibberSwift.git",
       "state" : {
-        "revision" : "eef53a3fd81cfdc66daddf5ff1e8256dfad6e2d2",
-        "version" : "1.2.0"
+        "branch" : "fix/linux-foundation-networking",
+        "revision" : "eaa419ade64d0c3a6503496803a9eaca9f072040"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/apns.git", exact: "5.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", exact: "1.11.0"),
         .package(url: "https://github.com/chrisaljoudi/swift-log-oslog.git", exact: "0.2.2"),
-        .package(url: "https://github.com/ppeelen/TibberSwift.git", from: "1.2.0"),
+        .package(url: "https://github.com/juliankahnert/TibberSwift.git", branch: "fix/linux-foundation-networking"),
         .package(url: "https://github.com/apple/swift-distributed-actors", revision: "0041f6a"),
         .package(url: "https://github.com/apple/swift-async-algorithms", exact: "1.1.3"),
         .package(url: "https://github.com/swift-server-community/APNSwift", exact: "6.5.0"),


### PR DESCRIPTION
## Summary
- Upstream TibberSwift 1.2.0 is missing `import FoundationNetworking` which is required on Linux for `URLRequest`, `URLSession`, etc.
- This broke the Docker build ([CI run](https://github.com/JulianKahnert/HomeAutomation/actions/runs/24159653799))
- Switches to the fork at `juliankahnert/TibberSwift` branch `fix/linux-foundation-networking` which adds the conditional import

## Test plan
- [x] `swift build` passes locally
- [ ] Docker CI build passes