### PR TITLE
Center brightness ramp on sunrise/sunset using nautical twilight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,15 @@ Before committing changes that affect iOS apps:
    cd Apps/FlowKitController && xcodebuild -project "FlowKit Controller.xcodeproj" -scheme "FlowKit Controller" -sdk iphonesimulator -configuration Debug build
    ```
 
-4. Ensure all builds pass before committing
+4. **All builds must pass before committing** — `swift build` AND every affected `xcodebuild` invocation. A failing iOS build is a blocker, not "unrelated"; if `xcodebuild` errors with macro fingerprint validation or related Swift Package Manager security warnings, run the workaround in step 5 below and re-build until it succeeds.
+
+5. **If `xcodebuild` fails with macro fingerprint / package plugin trust errors** (e.g. `Package validation failed`, `IDESkipPackagePluginFingerprintValidatation`, refused macros from `swift-dependencies`, `swift-composable-architecture`, `swift-case-paths`, `swift-perception`, `swift-openapi-generator`):
+
+   ```bash
+   cd Apps/FlowKitAdapter/ci_scripts && ./ci_post_clone.sh
+   ```
+
+   The script regenerates `macros.json` from the current `Package.resolved` fingerprints, copies it into `~/Library/org.swift.swiftpm/security/`, and disables the Xcode fingerprint check. The same approach works for `Apps/FlowKitController/ci_scripts/` if it exists. After running the script, re-run the failing `xcodebuild` command — it must then succeed before you commit.
 
 ## Project Structure
 
@@ -418,3 +426,15 @@ Additional workflows: `docker-branches.yaml` (branch image builds), `docker-tag.
 **Cause**: Xcode projects have separate build configuration from SPM
 
 **Solution**: Ensure all dependencies are properly linked in Xcode project settings
+
+### `xcodebuild` fails with macro fingerprint / package plugin trust errors
+
+**Cause**: Xcode validates the fingerprint of every Swift macro and package plugin against `~/Library/org.swift.swiftpm/security/macros.json`. After dependency updates (or on a fresh clone) the local fingerprints no longer match what `Package.resolved` references, so Xcode refuses to load the macros and the build fails before compilation.
+
+**Solution**: Use the helper script that ships with the repo — it rebuilds `macros.json` from the current `Package.resolved` and disables the fingerprint check:
+
+```bash
+cd Apps/FlowKitAdapter/ci_scripts && ./ci_post_clone.sh
+```
+
+This is the same script Xcode Cloud runs after cloning. Re-run `xcodebuild` afterwards; the build must then succeed before any commit. **Do not skip the iOS build assuming the failure is "environmental" — if the workaround does not fix it, treat it as a real bug to investigate.**

--- a/Sources/HAModels/Entities/SwitchDevice.swift
+++ b/Sources/HAModels/Entities/SwitchDevice.swift
@@ -67,7 +67,7 @@ open class SwitchDevice: Codable, @unchecked Sendable, Validatable, Log {
         if let colorTemperatureId {
             await hm.perform(.setColorTemperature(colorTemperatureId, value))
         } else if let rgbId {
-            let rgb = componentsForColorTemperature(normalzied: value)
+            let rgb = componentsForColorTemperature(normalized: value)
             await hm.perform(.setRGB(rgbId, rgb: rgb))
         }
     }

--- a/Sources/HAModels/Helper/CircadianLight.swift
+++ b/Sources/HAModels/Helper/CircadianLight.swift
@@ -7,24 +7,29 @@
 
 import Foundation
 
-/// Half-width (as a fraction of a day) of the dawn/dusk ramp used when civil
-/// twilight times are not available on the supplied ``SunData``. Approximates
-/// civil twilight at mid-latitudes (~43 min) so the curve stays close to the
-/// "with twilight" shape near 53°N.
+/// Half-width (as a fraction of a day) of the dawn/dusk ramp used as a
+/// fallback when nautical twilight is not available — typically near the
+/// summer solstice at mid-latitudes when nautical dusk wraps past midnight.
+/// ~43 min, roughly the civil-twilight duration at 53°N around the equinox.
 private let fallbackRampHalfWidth: Double = 0.03
 
 /// Returns the circadian brightness target (`0…1`) for the given moment.
 ///
-/// When civil twilight is available on the supplied ``SunData``, the curve
-/// holds at `0` until civil dawn, ramps up to `1` at sunrise, stays at `1`
-/// throughout the day, ramps back down to `0` at civil dusk, and stays at
-/// `0` for the rest of the night. Anchoring the ramp endpoints to actual
-/// astronomical events lets the curve stretch with summer twilights and
-/// contract with shorter winter ones automatically.
+/// The cosine ease-in-out ramps are centred on `sunrise` and `sunset` with
+/// a half-width derived from nautical twilight (sun 12° below horizon),
+/// giving a ~75 min "golden-hour" easing on either side of the horizon
+/// crossing at mid-latitudes around the equinox. Brightness already drops
+/// before sunset and only reaches `0` at nautical dusk; perceived daylight
+/// is matched more closely than with sunrise/sunset as the ramp endpoints.
 ///
-/// When civil twilight is not provided (e.g. high latitudes in summer where
-/// the sun never goes 6° below the horizon, or sun data constructed by hand
-/// without it), the curve falls back to a centered cosine ramp of
+/// `sunrise` and `sunset` sit at the `0.5` point of their respective ramps;
+/// nautical dawn/dusk sit at `0`. The full-brightness plateau spans from one
+/// nautical-twilight duration after sunrise to the same duration before
+/// sunset.
+///
+/// When nautical twilight is not provided — high latitudes near the summer
+/// solstice where the sun never dips 12° below the horizon, or sun data
+/// constructed by hand without it — the curve falls back to a fixed
 /// ``fallbackRampHalfWidth`` around sunrise/sunset.
 ///
 /// Polar regions without a sunrise/sunset return `0` because `sunData` is
@@ -33,21 +38,20 @@ public func getNormalizedBrightnessValue(sunData: SunData? = nil, current: Doubl
     guard let sunData = sunData ?? getSunData() else { return 0 }
     let current = current ?? Date().percentageOfDay()
 
-    let dawnStart: Double
-    let dawnEnd: Double
-    let duskStart: Double
-    let duskEnd: Double
-    if let civilDawn = sunData.civilDawn, let civilDusk = sunData.civilDusk {
-        dawnStart = civilDawn
-        dawnEnd = sunData.sunrise
-        duskStart = sunData.sunset
-        duskEnd = civilDusk
+    let dawnHalf: Double
+    let duskHalf: Double
+    if let nautDawn = sunData.nauticalDawn, let nautDusk = sunData.nauticalDusk {
+        dawnHalf = max(0, sunData.sunrise - nautDawn)
+        duskHalf = max(0, nautDusk - sunData.sunset)
     } else {
-        dawnStart = sunData.sunrise - fallbackRampHalfWidth
-        dawnEnd = sunData.sunrise + fallbackRampHalfWidth
-        duskStart = sunData.sunset - fallbackRampHalfWidth
-        duskEnd = sunData.sunset + fallbackRampHalfWidth
+        dawnHalf = fallbackRampHalfWidth
+        duskHalf = fallbackRampHalfWidth
     }
+
+    let dawnStart = sunData.sunrise - dawnHalf
+    let dawnEnd = sunData.sunrise + dawnHalf
+    let duskStart = sunData.sunset - duskHalf
+    let duskEnd = sunData.sunset + duskHalf
 
     let value: Double
     if current <= dawnStart || current >= duskEnd {
@@ -109,12 +113,23 @@ public func getSunData(for date: Date = Date()) -> SunData? {
         return nil
     }
 
-    return SunData(sunrise: sunrise.date.percentageOfDay(),
-                   sunset: sunset.date.percentageOfDay(),
+    let sunriseFraction = sunrise.date.percentageOfDay()
+    let sunsetFraction = sunset.date.percentageOfDay()
+
+    // Nautical twilight times computed by `Sun.schedule` can wrap past midnight
+    // at mid-latitudes around the summer solstice (the sun barely dips 12°
+    // below the horizon, so dusk lands early next morning and gets reported
+    // as a small fraction-of-day value). Discard those wrap-arounds so the
+    // brightness curve falls back to the constant ramp width.
+    let nauticalDawnFraction = today.nauticalDawn?.date.percentageOfDay()
+    let nauticalDuskFraction = today.nauticalDusk?.date.percentageOfDay()
+
+    return SunData(sunrise: sunriseFraction,
+                   sunset: sunsetFraction,
                    solarNoon: today.solarNoon.date.percentageOfDay(),
                    solarMidnight: today.solarMidnight.date.percentageOfDay(),
-                   civilDawn: today.civilDawn?.date.percentageOfDay(),
-                   civilDusk: today.civilDusk?.date.percentageOfDay())
+                   nauticalDawn: nauticalDawnFraction.flatMap { $0 < sunriseFraction ? $0 : nil },
+                   nauticalDusk: nauticalDuskFraction.flatMap { $0 > sunsetFraction ? $0 : nil })
 }
 
 /// Data for the sun
@@ -126,20 +141,20 @@ public struct SunData: Sendable {
                 sunset: Double,
                 solarNoon: Double,
                 solarMidnight: Double,
-                civilDawn: Double? = nil,
-                civilDusk: Double? = nil) {
+                nauticalDawn: Double? = nil,
+                nauticalDusk: Double? = nil) {
         for value in [sunrise, sunset, solarNoon, solarMidnight] {
             assert((0...1).contains(value), "Wrong value for sun data: \(value)")
         }
-        for value in [civilDawn, civilDusk].compactMap({ $0 }) {
+        for value in [nauticalDawn, nauticalDusk].compactMap({ $0 }) {
             assert((0...1).contains(value), "Wrong twilight value for sun data: \(value)")
         }
         self.sunrise = sunrise.clamped(to: 0...1)
         self.sunset = sunset.clamped(to: 0...1)
         self.solarNoon = solarNoon.clamped(to: 0...1)
         self.solarMidnight = solarMidnight.clamped(to: 0...1)
-        self.civilDawn = civilDawn?.clamped(to: 0...1)
-        self.civilDusk = civilDusk?.clamped(to: 0...1)
+        self.nauticalDawn = nauticalDawn?.clamped(to: 0...1)
+        self.nauticalDusk = nauticalDusk?.clamped(to: 0...1)
     }
 
     public let sunrise: Double
@@ -147,10 +162,11 @@ public struct SunData: Sendable {
     public let solarNoon: Double
     public let solarMidnight: Double
 
-    /// Civil dawn (sun 6° below the horizon, ascending). Optional because at
-    /// high latitudes in summer the sun never dips that far below the horizon.
-    public let civilDawn: Double?
+    /// Nautical dawn (sun 12° below the horizon, ascending). Optional — at
+    /// mid-latitudes around the summer solstice the sun never dips this far,
+    /// or its dawn/dusk crossings wrap past midnight.
+    public let nauticalDawn: Double?
 
-    /// Civil dusk (sun 6° below the horizon, descending). Same caveat as ``civilDawn``.
-    public let civilDusk: Double?
+    /// Nautical dusk (sun 12° below the horizon, descending). Same caveat as ``nauticalDawn``.
+    public let nauticalDusk: Double?
 }

--- a/Sources/HAModels/Helper/CircadianLight.swift
+++ b/Sources/HAModels/Helper/CircadianLight.swift
@@ -5,39 +5,100 @@
 //  Created by Julian Kahnert on 25.07.24.
 //
 
-// swiftlint:disable identifier_name
-
 import Foundation
 
+/// Half-width (as a fraction of a day) of the dawn/dusk ramp used when civil
+/// twilight times are not available on the supplied ``SunData``. Approximates
+/// civil twilight at mid-latitudes (~43 min) so the curve stays close to the
+/// "with twilight" shape near 53°N.
+private let fallbackRampHalfWidth: Double = 0.03
+
+/// Returns the circadian brightness target (`0…1`) for the given moment.
+///
+/// When civil twilight is available on the supplied ``SunData``, the curve
+/// holds at `0` until civil dawn, ramps up to `1` at sunrise, stays at `1`
+/// throughout the day, ramps back down to `0` at civil dusk, and stays at
+/// `0` for the rest of the night. Anchoring the ramp endpoints to actual
+/// astronomical events lets the curve stretch with summer twilights and
+/// contract with shorter winter ones automatically.
+///
+/// When civil twilight is not provided (e.g. high latitudes in summer where
+/// the sun never goes 6° below the horizon, or sun data constructed by hand
+/// without it), the curve falls back to a centered cosine ramp of
+/// ``fallbackRampHalfWidth`` around sunrise/sunset.
+///
+/// Polar regions without a sunrise/sunset return `0` because `sunData` is
+/// `nil`; callers such as ``MotionAtNight`` clamp this to a configured floor.
 public func getNormalizedBrightnessValue(sunData: SunData? = nil, current: Double? = nil) -> Float {
     guard let sunData = sunData ?? getSunData() else { return 0 }
     let current = current ?? Date().percentageOfDay()
 
-    let adjustment = 0.1
-
-    let value: Double
-    if (sunData.sunrise + adjustment...sunData.sunset - adjustment).contains(current) {
-        value = 1
-    } else if current < sunData.sunrise + adjustment {
-        value = sin(1 / (sunData.sunrise + adjustment) * .pi * current - (0.5 * .pi)) / 2 + 0.5
+    let dawnStart: Double
+    let dawnEnd: Double
+    let duskStart: Double
+    let duskEnd: Double
+    if let civilDawn = sunData.civilDawn, let civilDusk = sunData.civilDusk {
+        dawnStart = civilDawn
+        dawnEnd = sunData.sunrise
+        duskStart = sunData.sunset
+        duskEnd = civilDusk
     } else {
-
-        let a = 1 / (1 - sunData.sunset + adjustment)
-        value = cos(a * .pi * (current - sunData.sunset + adjustment)) / 2 + 0.5
+        dawnStart = sunData.sunrise - fallbackRampHalfWidth
+        dawnEnd = sunData.sunrise + fallbackRampHalfWidth
+        duskStart = sunData.sunset - fallbackRampHalfWidth
+        duskEnd = sunData.sunset + fallbackRampHalfWidth
     }
 
-    return Float(value)
+    let value: Double
+    if current <= dawnStart || current >= duskEnd {
+        value = 0
+    } else if current >= dawnEnd && current <= duskStart {
+        value = 1
+    } else if current < dawnEnd, dawnEnd > dawnStart {
+        let progress = (current - dawnStart) / (dawnEnd - dawnStart)
+        value = (1 - cos(.pi * progress)) / 2
+    } else if duskEnd > duskStart {
+        let progress = (current - duskStart) / (duskEnd - duskStart)
+        value = (1 + cos(.pi * progress)) / 2
+    } else {
+        // Degenerate ramp window (zero width) — fall through to bright.
+        value = 1
+    }
+
+    return Float(value.clamped(to: 0...1))
 }
 
+/// Returns the circadian color-temperature target (`0` = warmest, `1` = coolest)
+/// for the given moment.
+///
+/// The curve is anchored to the sun: warm before `sunrise` and after `sunset`,
+/// smoothly ramping up from `sunrise` to the coolest point at `solarNoon`, and
+/// back down to warm at `sunset`. Anchoring to `sunrise`/`sunset` (and not
+/// only `solarNoon`) keeps short winter evenings warm immediately after sunset
+/// instead of staying cool well into the night.
 public func getNormalizedColorTemperatureValue(sunData: SunData? = nil, current: Double? = nil) -> Float {
     guard let sunData = sunData ?? getSunData() else { return 0 }
     let current = current ?? Date().percentageOfDay()
 
-    let steepness: Double = 1.3
-    let x = steepness * (current - sunData.solarNoon + 0.5 / steepness)
-    let value = -1 * cos(2 * .pi * x.clamped(to: 0...1)) / 2 + 0.5
+    let morningSpan = sunData.solarNoon - sunData.sunrise
+    let afternoonSpan = sunData.sunset - sunData.solarNoon
 
-    return Float(value)
+    let value: Double
+    if current <= sunData.sunrise || current >= sunData.sunset {
+        value = 0
+    } else if current < sunData.solarNoon, morningSpan > 0 {
+        let progress = (current - sunData.sunrise) / morningSpan
+        value = (1 - cos(.pi * progress)) / 2
+    } else if afternoonSpan > 0 {
+        let progress = (current - sunData.solarNoon) / afternoonSpan
+        value = (1 + cos(.pi * progress)) / 2
+    } else {
+        // Degenerate sun data (sunrise == solarNoon or solarNoon == sunset).
+        // Return the neutral warm value rather than dividing by zero.
+        value = 0
+    }
+
+    return Float(value.clamped(to: 0...1))
 }
 
 public func getSunData(for date: Date = Date()) -> SunData? {
@@ -51,7 +112,9 @@ public func getSunData(for date: Date = Date()) -> SunData? {
     return SunData(sunrise: sunrise.date.percentageOfDay(),
                    sunset: sunset.date.percentageOfDay(),
                    solarNoon: today.solarNoon.date.percentageOfDay(),
-                   solarMidnight: today.solarMidnight.date.percentageOfDay())
+                   solarMidnight: today.solarMidnight.date.percentageOfDay(),
+                   civilDawn: today.civilDawn?.date.percentageOfDay(),
+                   civilDusk: today.civilDusk?.date.percentageOfDay())
 }
 
 /// Data for the sun
@@ -59,18 +122,35 @@ public func getSunData(for date: Date = Date()) -> SunData? {
 /// All parameters are normalized to the current day with values between 0 and 1.
 /// E.g. sunrise = 0.25 means that the sun rises at 6:00 am.
 public struct SunData: Sendable {
-    public init(sunrise: Double, sunset: Double, solarNoon: Double, solarMidnight: Double) {
+    public init(sunrise: Double,
+                sunset: Double,
+                solarNoon: Double,
+                solarMidnight: Double,
+                civilDawn: Double? = nil,
+                civilDusk: Double? = nil) {
         for value in [sunrise, sunset, solarNoon, solarMidnight] {
             assert((0...1).contains(value), "Wrong value for sun data: \(value)")
+        }
+        for value in [civilDawn, civilDusk].compactMap({ $0 }) {
+            assert((0...1).contains(value), "Wrong twilight value for sun data: \(value)")
         }
         self.sunrise = sunrise.clamped(to: 0...1)
         self.sunset = sunset.clamped(to: 0...1)
         self.solarNoon = solarNoon.clamped(to: 0...1)
         self.solarMidnight = solarMidnight.clamped(to: 0...1)
+        self.civilDawn = civilDawn?.clamped(to: 0...1)
+        self.civilDusk = civilDusk?.clamped(to: 0...1)
     }
 
     public let sunrise: Double
     public let sunset: Double
     public let solarNoon: Double
     public let solarMidnight: Double
+
+    /// Civil dawn (sun 6° below the horizon, ascending). Optional because at
+    /// high latitudes in summer the sun never dips that far below the horizon.
+    public let civilDawn: Double?
+
+    /// Civil dusk (sun 6° below the horizon, descending). Same caveat as ``civilDawn``.
+    public let civilDusk: Double?
 }

--- a/Sources/HAModels/Helper/ColorTempRGB.swift
+++ b/Sources/HAModels/Helper/ColorTempRGB.swift
@@ -26,9 +26,18 @@ public struct RGB: Sendable, Hashable, Codable, Equatable {
     }
 }
 
-public func componentsForColorTemperature(normalzied value: Float) -> RGB {
-    let range: ClosedRange<Float> = 2000...4000
-    let kelvin = (range.upperBound - range.lowerBound) * value + range.lowerBound
+/// Maps a normalized `0…1` value (`0` = warmest, `1` = coolest) to an RGB
+/// color along the blackbody curve.
+///
+/// The mapping is linear in **mired** (not Kelvin) across 154…500 mired,
+/// which corresponds to ≈ 6500K…2000K. This matches the scale used by the
+/// HomeKit native color-temperature characteristic, so a given normalized
+/// input produces visually similar results on both paths
+/// (see ``HomeKitAdapter/perform(_:)`` for the native scaling).
+public func componentsForColorTemperature(normalized value: Float) -> RGB {
+    let miredRange: ClosedRange<Float> = 154...500
+    let mired = miredRange.upperBound - (miredRange.upperBound - miredRange.lowerBound) * value
+    let kelvin = 1_000_000 / mired
 
     return componentsForColorTemperature(temperatureInKelvin: kelvin)
 }

--- a/Sources/HAModels/Helper/Sun.swift
+++ b/Sources/HAModels/Helper/Sun.swift
@@ -51,10 +51,13 @@ public struct SunSchedule {
     public var sunrise: SunPosition?
     public var sunset: SunPosition?
 
-    // Optional: at high latitudes the sun can stay within 6° of the horizon
-    // throughout the night, so civil twilight is not always defined.
-    public var civilDawn: SunPosition?
-    public var civilDusk: SunPosition?
+    // Optional: nautical twilight (sun 12° below horizon) is undefined whenever
+    // the sun stays brighter than that all night — common at mid-latitudes
+    // around the summer solstice. Even when defined, the times can wrap past
+    // midnight in summer; consumers should compare against `sunset`/`sunrise`
+    // before relying on them.
+    public var nauticalDawn: SunPosition?
+    public var nauticalDusk: SunPosition?
 }
 
 public class Sun {
@@ -64,10 +67,11 @@ public class Sun {
     /// radius (~16′). Used by `sunriseOrSet` for sunrise/sunset.
     private static let sunriseZenith: Double = 90.833
 
-    /// Zenith angle (in degrees) defining civil twilight: the sun is 6° below the
-    /// geometric horizon. Used to compute civil dawn (morning) and civil dusk
-    /// (evening), the practical limits of usable outdoor daylight.
-    private static let civilTwilightZenith: Double = 96.0
+    /// Zenith angle (in degrees) defining nautical twilight: the sun is 12° below
+    /// the geometric horizon. The "golden-hour boundary" — beyond this, only the
+    /// brightest celestial bodies remain visible. Used as the anchor for the
+    /// circadian brightness ramp; see ``getNormalizedBrightnessValue(sunData:current:)``.
+    private static let nauticalTwilightZenith: Double = 102.0
 
     /// Relation of a date to a sun event, compared at minute granularity.
     public enum SunElevation {
@@ -131,17 +135,17 @@ public class Sun {
             sunset = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(setMin * 60.0), calendar: calendar, timeZone: timeZone)
         }
 
-        var civilDawn: SunPosition?
-        if let dawnMin = sunriseOrSet(rise: true, zenithDegrees: civilTwilightZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
-            civilDawn = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(dawnMin * 60.0), calendar: calendar, timeZone: timeZone)
+        var nauticalDawn: SunPosition?
+        if let dawnMin = sunriseOrSet(rise: true, zenithDegrees: nauticalTwilightZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
+            nauticalDawn = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(dawnMin * 60.0), calendar: calendar, timeZone: timeZone)
         }
 
-        var civilDusk: SunPosition?
-        if let duskMin = sunriseOrSet(rise: false, zenithDegrees: civilTwilightZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
-            civilDusk = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(duskMin * 60.0), calendar: calendar, timeZone: timeZone)
+        var nauticalDusk: SunPosition?
+        if let duskMin = sunriseOrSet(rise: false, zenithDegrees: nauticalTwilightZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
+            nauticalDusk = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(duskMin * 60.0), calendar: calendar, timeZone: timeZone)
         }
 
-        return SunSchedule(position: currentPosition, startOfDay: startOfDay, endOfDay: endOfDay, solarNoon: solarNoon, solarMidnight: solarMidnight, sunrise: sunrise, sunset: sunset, civilDawn: civilDawn, civilDusk: civilDusk)
+        return SunSchedule(position: currentPosition, startOfDay: startOfDay, endOfDay: endOfDay, solarNoon: solarNoon, solarMidnight: solarMidnight, sunrise: sunrise, sunset: sunset, nauticalDawn: nauticalDawn, nauticalDusk: nauticalDusk)
     }
 
     public static func position(latitude: Double, longitude: Double, date: Date?) -> SunPosition? {

--- a/Sources/HAModels/Helper/Sun.swift
+++ b/Sources/HAModels/Helper/Sun.swift
@@ -50,9 +50,24 @@ public struct SunSchedule {
     // Optional: some days in some locations never have a sunrise and/or sunset
     public var sunrise: SunPosition?
     public var sunset: SunPosition?
+
+    // Optional: at high latitudes the sun can stay within 6° of the horizon
+    // throughout the night, so civil twilight is not always defined.
+    public var civilDawn: SunPosition?
+    public var civilDusk: SunPosition?
 }
 
 public class Sun {
+
+    /// Zenith angle (in degrees) at which the geometric centre of the sun crosses
+    /// the horizon, including atmospheric refraction (~34′) and the sun's apparent
+    /// radius (~16′). Used by `sunriseOrSet` for sunrise/sunset.
+    private static let sunriseZenith: Double = 90.833
+
+    /// Zenith angle (in degrees) defining civil twilight: the sun is 6° below the
+    /// geometric horizon. Used to compute civil dawn (morning) and civil dusk
+    /// (evening), the practical limits of usable outdoor daylight.
+    private static let civilTwilightZenith: Double = 96.0
 
     /// Relation of a date to a sun event, compared at minute granularity.
     public enum SunElevation {
@@ -107,16 +122,26 @@ public class Sun {
         else { return nil }
 
         var sunrise: SunPosition?
-        if let riseMin = sunriseOrSet(rise: true, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
+        if let riseMin = sunriseOrSet(rise: true, zenithDegrees: sunriseZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
             sunrise = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(riseMin * 60.0), calendar: calendar, timeZone: timeZone)
         }
 
         var sunset: SunPosition?
-        if let setMin = sunriseOrSet(rise: false, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
+        if let setMin = sunriseOrSet(rise: false, zenithDegrees: sunriseZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
             sunset = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(setMin * 60.0), calendar: calendar, timeZone: timeZone)
         }
 
-        return SunSchedule(position: currentPosition, startOfDay: startOfDay, endOfDay: endOfDay, solarNoon: solarNoon, solarMidnight: solarMidnight, sunrise: sunrise, sunset: sunset)
+        var civilDawn: SunPosition?
+        if let dawnMin = sunriseOrSet(rise: true, zenithDegrees: civilTwilightZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
+            civilDawn = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(dawnMin * 60.0), calendar: calendar, timeZone: timeZone)
+        }
+
+        var civilDusk: SunPosition?
+        if let duskMin = sunriseOrSet(rise: false, zenithDegrees: civilTwilightZenith, JD: JT.julianDay, latitude: latitude, longitude: longitude, timezoneOffset: JT.timezoneOffset) {
+            civilDusk = position(latitude: latitude, longitude: longitude, date: JT.startOfDay.addingTimeInterval(duskMin * 60.0), calendar: calendar, timeZone: timeZone)
+        }
+
+        return SunSchedule(position: currentPosition, startOfDay: startOfDay, endOfDay: endOfDay, solarNoon: solarNoon, solarMidnight: solarMidnight, sunrise: sunrise, sunset: sunset, civilDawn: civilDawn, civilDusk: civilDusk)
     }
 
     public static func position(latitude: Double, longitude: Double, date: Date?) -> SunPosition? {
@@ -210,26 +235,26 @@ public class Sun {
         return SunPosition(date: date, azimuth: azimuth, elevation: elevation)
     }
 
-    private static func hourAngleSunrise(latitude: Double, declination: Double) -> Double {
+    private static func hourAngleAtZenith(_ zenithDegrees: Double, latitude: Double, declination: Double) -> Double {
         let latRad = degreesToRadians(latitude)
         let sdRad = degreesToRadians(declination)
-        return acos(cos(degreesToRadians(90.833)) / (cos(latRad) * cos(sdRad)) - tan(latRad) * tan(sdRad))
+        return acos(cos(degreesToRadians(zenithDegrees)) / (cos(latRad) * cos(sdRad)) - tan(latRad) * tan(sdRad))
     }
 
-    private static func sunriseOrSetUTC(rise: Bool, JD: Double, latitude: Double, longitude: Double) -> Double {
+    private static func sunriseOrSetUTC(rise: Bool, zenithDegrees: Double, JD: Double, latitude: Double, longitude: Double) -> Double {
         let t = julianCent(julianDay: JD)
         let eqTime = equationOfTime(T: t)
         let solarDec = sunDeclination(T: t)
-        var hourAngle = hourAngleSunrise(latitude: latitude, declination: solarDec)
+        var hourAngle = hourAngleAtZenith(zenithDegrees, latitude: latitude, declination: solarDec)
         if !rise { hourAngle = -hourAngle }
         let delta = longitude + radiansToDegrees(hourAngle)
         return 720 - (4.0 * delta) - eqTime // in minutes
     }
 
-    private static func sunriseOrSet(rise: Bool, JD: Double, latitude: Double, longitude: Double, timezoneOffset: Double) -> Double? {
-        let timeUTC = sunriseOrSetUTC(rise: rise, JD: JD, latitude: latitude, longitude: longitude)
-        let newTimeUTC = sunriseOrSetUTC(rise: rise, JD: JD + timeUTC / 1440.0, latitude: latitude, longitude: longitude)
-        if newTimeUTC.isNaN { return nil } // no sunrise/set on this day in this location (like North/South Pole)
+    private static func sunriseOrSet(rise: Bool, zenithDegrees: Double, JD: Double, latitude: Double, longitude: Double, timezoneOffset: Double) -> Double? {
+        let timeUTC = sunriseOrSetUTC(rise: rise, zenithDegrees: zenithDegrees, JD: JD, latitude: latitude, longitude: longitude)
+        let newTimeUTC = sunriseOrSetUTC(rise: rise, zenithDegrees: zenithDegrees, JD: JD + timeUTC / 1440.0, latitude: latitude, longitude: longitude)
+        if newTimeUTC.isNaN { return nil } // event does not occur on this day at this latitude
 
         let timezone = timezoneOffset / 3600.0
         var timeLocal = newTimeUTC + (timezone * 60.0)

--- a/Tests/HomeAutomationKitTests/HelperTests/CircadianLightTests.swift
+++ b/Tests/HomeAutomationKitTests/HelperTests/CircadianLightTests.swift
@@ -11,25 +11,28 @@ import Testing
 
 struct CircadianTests {
 
-    /// Symmetric, easy-to-reason-about sun data with civil twilight ≈ 36 min:
-    /// civil dawn 05:24, sunrise 06:00, solar noon 12:00, sunset 18:00, civil dusk 18:36.
+    /// Symmetric, easy-to-reason-about sun data: nautical dawn 04:42, sunrise
+    /// 06:00, solar noon 12:00, sunset 18:00, nautical dusk 19:18. Nautical
+    /// twilight is ≈ 78 min wide (matching mid-latitudes around the equinox).
     private static let standardSunData = SunData(sunrise: 0.25,
                                                  sunset: 0.75,
                                                  solarNoon: 0.5,
                                                  solarMidnight: 0.0,
-                                                 civilDawn: 0.225,
-                                                 civilDusk: 0.775)
+                                                 nauticalDawn: 0.196,
+                                                 nauticalDusk: 0.804)
 
-    /// Short winter day at Oldenburg: sunrise 08:00, sunset 16:15, civil
-    /// twilight ≈ 42 min on either side.
+    /// Short winter day at Oldenburg: sunrise 08:00, sunset 16:15,
+    /// nautical twilight ≈ 88 min on either side.
     private static let winterSunData = SunData(sunrise: 8.0 / 24.0,
                                                sunset: 16.25 / 24.0,
                                                solarNoon: 12.125 / 24.0,
                                                solarMidnight: 0.00,
-                                               civilDawn: (8.0 - 42.0 / 60.0) / 24.0,
-                                               civilDusk: (16.25 + 42.0 / 60.0) / 24.0)
+                                               nauticalDawn: (8.0 - 88.0 / 60.0) / 24.0,
+                                               nauticalDusk: (16.25 + 88.0 / 60.0) / 24.0)
 
-    /// Sun data without civil twilight info — exercises the fallback ramp.
+    /// Sun data without nautical twilight info — exercises the constant
+    /// fallback ramp used near the summer solstice when nautical dusk wraps
+    /// past midnight.
     private static let sunDataWithoutTwilight = SunData(sunrise: 0.25,
                                                         sunset: 0.75,
                                                         solarNoon: 0.5,
@@ -39,7 +42,7 @@ struct CircadianTests {
         (hour * 3600 + minute * 60) / 86_400
     }
 
-    // MARK: - Brightness curve (with civil twilight)
+    // MARK: - Brightness curve (nautical-twilight-anchored)
 
     @Test("Brightness at solar noon is full")
     func brightnessAtSolarNoon() {
@@ -48,41 +51,74 @@ struct CircadianTests {
         #expect(value == 1)
     }
 
-    @Test("Brightness at sunrise is full (dawn ramp ends here)")
+    @Test("Brightness at sunrise is 0.5 (midpoint of the dawn ramp)")
     func brightnessAtSunrise() {
+        // Cosine ramp is centred on sunrise, so the inflection point sits
+        // exactly there: lights are halfway between dark and full daylight.
         let value = getNormalizedBrightnessValue(sunData: Self.standardSunData,
                                                  current: Self.standardSunData.sunrise)
-        #expect(abs(value - 1.0) < 0.001)
+        #expect(abs(value - 0.5) < 0.001)
     }
 
-    @Test("Brightness at sunset is full (dusk ramp begins here)")
+    @Test("Brightness at sunset is 0.5 (midpoint of the dusk ramp)")
     func brightnessAtSunset() {
         let value = getNormalizedBrightnessValue(sunData: Self.standardSunData,
                                                  current: Self.standardSunData.sunset)
+        #expect(abs(value - 0.5) < 0.001)
+    }
+
+    @Test("Brightness at nautical dawn is zero (start of dawn ramp)")
+    func brightnessAtNauticalDawn() throws {
+        let nauticalDawn = try #require(Self.standardSunData.nauticalDawn)
+        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData, current: nauticalDawn)
+        #expect(abs(value - 0.0) < 0.001)
+    }
+
+    @Test("Brightness at nautical dusk is zero (end of dusk ramp)")
+    func brightnessAtNauticalDusk() throws {
+        let nauticalDusk = try #require(Self.standardSunData.nauticalDusk)
+        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData, current: nauticalDusk)
+        #expect(abs(value - 0.0) < 0.001)
+    }
+
+    @Test("Brightness reaches 1 one nautical-twilight after sunrise")
+    func brightnessAtPeakStart() throws {
+        let sun = Self.standardSunData
+        let nauticalDawn = try #require(sun.nauticalDawn)
+        let peakStart = sun.sunrise + (sun.sunrise - nauticalDawn)
+        let value = getNormalizedBrightnessValue(sunData: sun, current: peakStart)
         #expect(abs(value - 1.0) < 0.001)
     }
 
-    @Test("Brightness at civil dawn is zero (start of dawn ramp)")
-    func brightnessAtCivilDawn() throws {
-        let civilDawn = try #require(Self.standardSunData.civilDawn)
-        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData, current: civilDawn)
-        #expect(abs(value - 0.0) < 0.001)
-    }
-
-    @Test("Brightness at civil dusk is zero (end of dusk ramp)")
-    func brightnessAtCivilDusk() throws {
-        let civilDusk = try #require(Self.standardSunData.civilDusk)
-        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData, current: civilDusk)
-        #expect(abs(value - 0.0) < 0.001)
-    }
-
-    @Test("Brightness at the midpoint of civil dawn → sunrise is 0.5")
-    func brightnessAtDawnMidpoint() throws {
+    @Test("Brightness leaves 1 one nautical-twilight before sunset")
+    func brightnessAtPeakEnd() throws {
         let sun = Self.standardSunData
-        let civilDawn = try #require(sun.civilDawn)
-        let midpoint = (civilDawn + sun.sunrise) / 2
-        let value = getNormalizedBrightnessValue(sunData: sun, current: midpoint)
-        #expect(abs(value - 0.5) < 0.001)
+        let nauticalDusk = try #require(sun.nauticalDusk)
+        let peakEnd = sun.sunset - (nauticalDusk - sun.sunset)
+        let value = getNormalizedBrightnessValue(sunData: sun, current: peakEnd)
+        #expect(abs(value - 1.0) < 0.001)
+    }
+
+    @Test("Brightness is already dimming two minutes before sunset")
+    func brightnessJustBeforeSunset() {
+        // Real-world scenario: sunset 20:32, nautical dusk ≈ 78 min later
+        // (mid-April at 53°N). At 20:30 (two minutes before sunset) the
+        // dusk-ramp midpoint sits at sunset, so brightness must be a touch
+        // above 0.5 — well below 1.
+        let sunsetFraction = (20.0 + 32.0 / 60.0) / 24.0
+        let nautDuskFraction = sunsetFraction + (78.0 / 60.0) / 24.0
+        let nautDawnFraction = (5.0 + 8.0 / 60.0) / 24.0
+        let sunriseFraction = (6.0 + 26.0 / 60.0) / 24.0
+        let sun = SunData(sunrise: sunriseFraction,
+                          sunset: sunsetFraction,
+                          solarNoon: 13.5 / 24.0,
+                          solarMidnight: 1.5 / 24.0,
+                          nauticalDawn: nautDawnFraction,
+                          nauticalDusk: nautDuskFraction)
+        let twoMinutesBeforeSunset = (20.0 + 30.0 / 60.0) / 24.0
+        let value = getNormalizedBrightnessValue(sunData: sun, current: twoMinutesBeforeSunset)
+        #expect(value > 0.45 && value < 0.6,
+                "Expected ≈ 0.5 just before sunset, got \(value)")
     }
 
     @Test("Brightness deep in the night is zero")
@@ -97,20 +133,21 @@ struct CircadianTests {
 
     @Test("Brightness stays at zero after a winter sunset")
     func brightnessAfterWinterSunset() {
-        // 18:00 on a short December day is well past civil dusk (≈ 16:57) → must be 0.
+        // 18:00 on a short December day is well past nautical dusk (≈ 17:43) → 0.
         let value = getNormalizedBrightnessValue(sunData: Self.winterSunData,
                                                  current: fractionOfDay(hour: 18))
         #expect(value == 0)
     }
 
-    @Test("Brightness ramp is monotone non-decreasing across dawn")
+    @Test("Brightness ramp is monotone non-decreasing across the entire dawn ramp")
     func brightnessMonotoneAcrossDawn() throws {
         let sun = Self.standardSunData
-        let civilDawn = try #require(sun.civilDawn)
+        let nauticalDawn = try #require(sun.nauticalDawn)
+        let rampHalf = sun.sunrise - nauticalDawn
         let step = 0.002
-        var current = civilDawn - 0.01
+        var current = nauticalDawn - 0.01
         var previous = getNormalizedBrightnessValue(sunData: sun, current: current)
-        while current <= sun.sunrise + 0.01 {
+        while current <= sun.sunrise + rampHalf + 0.01 {
             let next = getNormalizedBrightnessValue(sunData: sun, current: current)
             #expect(next >= previous - 0.001)
             previous = next
@@ -118,14 +155,15 @@ struct CircadianTests {
         }
     }
 
-    @Test("Brightness ramp is monotone non-increasing across dusk")
+    @Test("Brightness ramp is monotone non-increasing across the entire dusk ramp")
     func brightnessMonotoneAcrossDusk() throws {
         let sun = Self.standardSunData
-        let civilDusk = try #require(sun.civilDusk)
+        let nauticalDusk = try #require(sun.nauticalDusk)
+        let rampHalf = nauticalDusk - sun.sunset
         let step = 0.002
-        var current = sun.sunset - 0.01
+        var current = sun.sunset - rampHalf - 0.01
         var previous = getNormalizedBrightnessValue(sunData: sun, current: current)
-        while current <= civilDusk + 0.01 {
+        while current <= nauticalDusk + 0.01 {
             let next = getNormalizedBrightnessValue(sunData: sun, current: current)
             #expect(next <= previous + 0.001)
             previous = next
@@ -133,12 +171,10 @@ struct CircadianTests {
         }
     }
 
-    // MARK: - Brightness curve fallback (no civil twilight provided)
+    // MARK: - Brightness curve fallback
 
-    @Test("Brightness falls back to a centered ramp when civil twilight is missing")
-    func brightnessFallbackCenteredOnSunrise() {
-        // Without civilDawn/civilDusk the ramp should still reach 1 in the middle of
-        // the day and 0 deep at night — the curve simply uses a constant half-width.
+    @Test("Constant fallback: brightness still reaches 1 at noon and 0 at night")
+    func brightnessConstantFallback() {
         let sun = Self.sunDataWithoutTwilight
         let atNoon = getNormalizedBrightnessValue(sunData: sun, current: sun.solarNoon)
         let atMidnight = getNormalizedBrightnessValue(sunData: sun, current: 0)

--- a/Tests/HomeAutomationKitTests/HelperTests/CircadianLightTests.swift
+++ b/Tests/HomeAutomationKitTests/HelperTests/CircadianLightTests.swift
@@ -11,50 +11,266 @@ import Testing
 
 struct CircadianTests {
 
-    /// Helper function to create a specific date
-    private func date(year: Int, month: Int, day: Int, hour: Int, minute: Int) throws -> Date {
-        var dateComponents = DateComponents()
-        dateComponents.year = year
-        dateComponents.month = month
-        dateComponents.day = day
-        dateComponents.hour = hour
-        dateComponents.minute = minute
-        let calendar = Calendar.current
-        return try #require(calendar.date(from: dateComponents))
+    /// Symmetric, easy-to-reason-about sun data with civil twilight ≈ 36 min:
+    /// civil dawn 05:24, sunrise 06:00, solar noon 12:00, sunset 18:00, civil dusk 18:36.
+    private static let standardSunData = SunData(sunrise: 0.25,
+                                                 sunset: 0.75,
+                                                 solarNoon: 0.5,
+                                                 solarMidnight: 0.0,
+                                                 civilDawn: 0.225,
+                                                 civilDusk: 0.775)
+
+    /// Short winter day at Oldenburg: sunrise 08:00, sunset 16:15, civil
+    /// twilight ≈ 42 min on either side.
+    private static let winterSunData = SunData(sunrise: 8.0 / 24.0,
+                                               sunset: 16.25 / 24.0,
+                                               solarNoon: 12.125 / 24.0,
+                                               solarMidnight: 0.00,
+                                               civilDawn: (8.0 - 42.0 / 60.0) / 24.0,
+                                               civilDusk: (16.25 + 42.0 / 60.0) / 24.0)
+
+    /// Sun data without civil twilight info — exercises the fallback ramp.
+    private static let sunDataWithoutTwilight = SunData(sunrise: 0.25,
+                                                        sunset: 0.75,
+                                                        solarNoon: 0.5,
+                                                        solarMidnight: 0.0)
+
+    private func fractionOfDay(hour: Double, minute: Double = 0) -> Double {
+        (hour * 3600 + minute * 60) / 86_400
     }
 
-    @Test("Test case for when the date is during the day (between sunrise and sunset)")
+    // MARK: - Brightness curve (with civil twilight)
+
+    @Test("Brightness at solar noon is full")
+    func brightnessAtSolarNoon() {
+        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData,
+                                                 current: Self.standardSunData.solarNoon)
+        #expect(value == 1)
+    }
+
+    @Test("Brightness at sunrise is full (dawn ramp ends here)")
+    func brightnessAtSunrise() {
+        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData,
+                                                 current: Self.standardSunData.sunrise)
+        #expect(abs(value - 1.0) < 0.001)
+    }
+
+    @Test("Brightness at sunset is full (dusk ramp begins here)")
+    func brightnessAtSunset() {
+        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData,
+                                                 current: Self.standardSunData.sunset)
+        #expect(abs(value - 1.0) < 0.001)
+    }
+
+    @Test("Brightness at civil dawn is zero (start of dawn ramp)")
+    func brightnessAtCivilDawn() throws {
+        let civilDawn = try #require(Self.standardSunData.civilDawn)
+        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData, current: civilDawn)
+        #expect(abs(value - 0.0) < 0.001)
+    }
+
+    @Test("Brightness at civil dusk is zero (end of dusk ramp)")
+    func brightnessAtCivilDusk() throws {
+        let civilDusk = try #require(Self.standardSunData.civilDusk)
+        let value = getNormalizedBrightnessValue(sunData: Self.standardSunData, current: civilDusk)
+        #expect(abs(value - 0.0) < 0.001)
+    }
+
+    @Test("Brightness at the midpoint of civil dawn → sunrise is 0.5")
+    func brightnessAtDawnMidpoint() throws {
+        let sun = Self.standardSunData
+        let civilDawn = try #require(sun.civilDawn)
+        let midpoint = (civilDawn + sun.sunrise) / 2
+        let value = getNormalizedBrightnessValue(sunData: sun, current: midpoint)
+        #expect(abs(value - 0.5) < 0.001)
+    }
+
+    @Test("Brightness deep in the night is zero")
+    func brightnessAtNight() {
+        let atTwoAM = getNormalizedBrightnessValue(sunData: Self.standardSunData,
+                                                   current: fractionOfDay(hour: 2))
+        let atMidnight = getNormalizedBrightnessValue(sunData: Self.standardSunData,
+                                                     current: 0)
+        #expect(atTwoAM == 0)
+        #expect(atMidnight == 0)
+    }
+
+    @Test("Brightness stays at zero after a winter sunset")
+    func brightnessAfterWinterSunset() {
+        // 18:00 on a short December day is well past civil dusk (≈ 16:57) → must be 0.
+        let value = getNormalizedBrightnessValue(sunData: Self.winterSunData,
+                                                 current: fractionOfDay(hour: 18))
+        #expect(value == 0)
+    }
+
+    @Test("Brightness ramp is monotone non-decreasing across dawn")
+    func brightnessMonotoneAcrossDawn() throws {
+        let sun = Self.standardSunData
+        let civilDawn = try #require(sun.civilDawn)
+        let step = 0.002
+        var current = civilDawn - 0.01
+        var previous = getNormalizedBrightnessValue(sunData: sun, current: current)
+        while current <= sun.sunrise + 0.01 {
+            let next = getNormalizedBrightnessValue(sunData: sun, current: current)
+            #expect(next >= previous - 0.001)
+            previous = next
+            current += step
+        }
+    }
+
+    @Test("Brightness ramp is monotone non-increasing across dusk")
+    func brightnessMonotoneAcrossDusk() throws {
+        let sun = Self.standardSunData
+        let civilDusk = try #require(sun.civilDusk)
+        let step = 0.002
+        var current = sun.sunset - 0.01
+        var previous = getNormalizedBrightnessValue(sunData: sun, current: current)
+        while current <= civilDusk + 0.01 {
+            let next = getNormalizedBrightnessValue(sunData: sun, current: current)
+            #expect(next <= previous + 0.001)
+            previous = next
+            current += step
+        }
+    }
+
+    // MARK: - Brightness curve fallback (no civil twilight provided)
+
+    @Test("Brightness falls back to a centered ramp when civil twilight is missing")
+    func brightnessFallbackCenteredOnSunrise() {
+        // Without civilDawn/civilDusk the ramp should still reach 1 in the middle of
+        // the day and 0 deep at night — the curve simply uses a constant half-width.
+        let sun = Self.sunDataWithoutTwilight
+        let atNoon = getNormalizedBrightnessValue(sunData: sun, current: sun.solarNoon)
+        let atMidnight = getNormalizedBrightnessValue(sunData: sun, current: 0)
+        #expect(atNoon == 1)
+        #expect(atMidnight == 0)
+    }
+
+    // MARK: - Color temperature curve
+
+    @Test("Color temperature peaks (cool) at solar noon")
+    func colorTemperatureAtSolarNoon() {
+        let value = getNormalizedColorTemperatureValue(sunData: Self.standardSunData,
+                                                       current: Self.standardSunData.solarNoon)
+        #expect(abs(value - 1.0) < 0.001)
+    }
+
+    @Test("Color temperature is warm at and before sunrise")
+    func colorTemperatureBeforeSunrise() {
+        let atSunrise = getNormalizedColorTemperatureValue(sunData: Self.standardSunData,
+                                                           current: Self.standardSunData.sunrise)
+        let atThreeAM = getNormalizedColorTemperatureValue(sunData: Self.standardSunData,
+                                                           current: 3.0 / 24.0)
+        #expect(atSunrise == 0)
+        #expect(atThreeAM == 0)
+    }
+
+    @Test("Color temperature is warm at and after sunset")
+    func colorTemperatureAfterSunset() {
+        let atSunset = getNormalizedColorTemperatureValue(sunData: Self.standardSunData,
+                                                          current: Self.standardSunData.sunset)
+        let atEvening = getNormalizedColorTemperatureValue(sunData: Self.standardSunData,
+                                                          current: 21.0 / 24.0)
+        #expect(atSunset == 0)
+        #expect(atEvening == 0)
+    }
+
+    /// Asserts that 45 minutes past a winter sunset the curve has already
+    /// dropped to fully warm — color temperature must follow the actual
+    /// daylight window, not just the symmetry around solar noon.
+    @Test("Color temperature drops to warm immediately after a winter sunset")
+    func colorTemperatureWinterEveningIsWarm() {
+        let sun = Self.winterSunData
+        let justAfterSunset = getNormalizedColorTemperatureValue(sunData: sun,
+                                                                 current: fractionOfDay(hour: 17))
+        #expect(justAfterSunset == 0)
+    }
+
+    @Test("Color temperature increases monotonically from sunrise to solar noon")
+    func colorTemperatureMorningRampIsMonotone() {
+        let sun = Self.standardSunData
+        let step = 0.005
+        var current = sun.sunrise
+        var previous = getNormalizedColorTemperatureValue(sunData: sun, current: current)
+        while current <= sun.solarNoon {
+            let next = getNormalizedColorTemperatureValue(sunData: sun, current: current)
+            #expect(next >= previous - 0.001)
+            previous = next
+            current += step
+        }
+    }
+
+    @Test("Color temperature decreases monotonically from solar noon to sunset")
+    func colorTemperatureAfternoonRampIsMonotone() {
+        let sun = Self.standardSunData
+        let step = 0.005
+        var current = sun.solarNoon
+        var previous = getNormalizedColorTemperatureValue(sunData: sun, current: current)
+        while current <= sun.sunset {
+            let next = getNormalizedColorTemperatureValue(sunData: sun, current: current)
+            #expect(next <= previous + 0.001)
+            previous = next
+            current += step
+        }
+    }
+
+    @Test("Color temperature at the midpoint of the morning ramp is 0.5")
+    func colorTemperatureMorningMidpoint() {
+        let sun = Self.standardSunData
+        let midpoint = (sun.sunrise + sun.solarNoon) / 2
+        let value = getNormalizedColorTemperatureValue(sunData: sun, current: midpoint)
+        #expect(abs(value - 0.5) < 0.001)
+    }
+
+    // MARK: - Real-date smoke tests
+
+    @Test("Values stay within 0…1 across a full day")
+    func valuesRemainNormalizedAllDay() {
+        let sun = Self.standardSunData
+        for minute in stride(from: 0, through: 24 * 60, by: 15) {
+            let current = Double(minute) / (24.0 * 60)
+            let brightness = getNormalizedBrightnessValue(sunData: sun, current: current)
+            let colorTemp = getNormalizedColorTemperatureValue(sunData: sun, current: current)
+            #expect((0...1).contains(brightness))
+            #expect((0...1).contains(colorTemp))
+        }
+    }
+
+    @Test("Midsummer midday stays at full brightness", .tags(.localOnly))
     func testCircadianPercentage_Daytime() throws {
-        let date = try self.date(year: 2023, month: 7, day: 25, hour: 12, minute: 0) // Solar noon
+        // setenv so the absolute `percentageOfDay()` resolves to local noon.
+        setenv("TZ", "Europe/Berlin", 1)
+        CFTimeZoneResetSystem()
+
+        var components = DateComponents()
+        components.year = 2023
+        components.month = 7
+        components.day = 25
+        components.hour = 12
+        let date = try #require(Calendar.current.date(from: components))
 
         let sunData = getSunData(for: date)
         let percentage = getNormalizedBrightnessValue(sunData: sunData, current: date.percentageOfDay())
-
-        #expect(percentage > 0)
-        #expect(percentage <= 1)
+        #expect(percentage == 1)
     }
 
-    @Test("Test case for when the date is during the night (between sunset and sunrise)", .tags(.localOnly))
+    @Test("Night-time brightness is zero (no dawn ramp bleed into the night)", .tags(.localOnly))
     func testCircadianPercentage_Nighttime() throws {
         setenv("TZ", "Europe/Berlin", 1)
         CFTimeZoneResetSystem()
 
-        let date = try self.date(year: 2023, month: 7, day: 25, hour: 2, minute: 0) // During night
+        var components = DateComponents()
+        components.year = 2023
+        components.month = 7
+        components.day = 25
+        components.hour = 2
+        let date = try #require(Calendar.current.date(from: components))
 
         let sunData = getSunData(for: date)
         let percentage = getNormalizedBrightnessValue(sunData: sunData, current: date.percentageOfDay())
 
-        #expect(percentage > 0.1)
-        #expect(percentage < 0.3)
-    }
-
-    @Test("Test case for when there's no sunrise or sunset (e.g., polar regions during certain seasons)")
-    func testCircadianPercentage_NoSunriseSunset() throws {
-        let date = try self.date(year: 2023, month: 7, day: 25, hour: 12, minute: 0)
-
-        let sunData = getSunData(for: date)
-        let percentage = getNormalizedBrightnessValue(sunData: sunData, current: date.percentageOfDay())
-
-        #expect(percentage == 1)
+        // 02:00 sits well before the dawn ramp window, so the curve must
+        // report `0` — the configured night-floor in callers takes over.
+        #expect(percentage == 0)
     }
 }

--- a/Tests/HomeAutomationKitTests/HelperTests/SunComparisonTests.swift
+++ b/Tests/HomeAutomationKitTests/HelperTests/SunComparisonTests.swift
@@ -113,83 +113,67 @@ struct SunComparisonTests {
         #expect(Sun.sunsetElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .below)
     }
 
-    // MARK: - Civil twilight (sun at zenith 96°, i.e. 6° below the horizon)
+    // MARK: - Nautical twilight (sun at zenith 102°, i.e. 12° below the horizon)
     //
     // Reference values for Oldenburg (53.14°N, 8.21°E) come from standard
     // astronomical tables (NOAA Solar Calculator algorithm, which is what
     // `Sun.swift` implements). Tolerances are ±5 min to absorb rounding and
     // small algorithmic differences while still failing on regressions.
-
-    private func civilTwilightComponents(year: Int, month: Int, day: Int, isDawn: Bool) throws -> (hour: Int, minute: Int) {
-        var calendar = Calendar.current
-        calendar.timeZone = timeZone
-        let refDate = try date(year: year, month: month, day: day, hour: 12, minute: 0)
-        let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
-        let position = try #require(isDawn ? schedule.civilDawn : schedule.civilDusk)
-        return (calendar.component(.hour, from: position.date), calendar.component(.minute, from: position.date))
-    }
+    // Nautical twilight is undefined at mid-latitudes around the summer
+    // solstice — the sun never dips 12° below the horizon there.
 
     private func minutesSinceMidnight(_ components: (hour: Int, minute: Int)) -> Int {
         components.hour * 60 + components.minute
     }
 
-    @Test("Spring equinox civil dawn at Oldenburg is ≈ 05:56 CET")
-    func civilDawnAtSpringEquinox() throws {
-        let actual = try civilTwilightComponents(year: 2026, month: 3, day: 20, isDawn: true)
-        let expected = 5 * 60 + 56
-        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
-                "Civil dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 05:56 CET")
+    private func nauticalTwilightComponents(year: Int, month: Int, day: Int, isDawn: Bool) throws -> (hour: Int, minute: Int) {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        let refDate = try date(year: year, month: month, day: day, hour: 12, minute: 0)
+        let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
+        let position = try #require(isDawn ? schedule.nauticalDawn : schedule.nauticalDusk)
+        return (calendar.component(.hour, from: position.date), calendar.component(.minute, from: position.date))
     }
 
-    @Test("Spring equinox civil dusk at Oldenburg is ≈ 19:17 CET")
-    func civilDuskAtSpringEquinox() throws {
-        let actual = try civilTwilightComponents(year: 2026, month: 3, day: 20, isDawn: false)
-        let expected = 19 * 60 + 17
+    @Test("Spring equinox nautical dawn at Oldenburg is ≈ 05:14 CET")
+    func nauticalDawnAtSpringEquinox() throws {
+        let actual = try nauticalTwilightComponents(year: 2026, month: 3, day: 20, isDawn: true)
+        let expected = 5 * 60 + 14
         #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
-                "Civil dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 19:17 CET")
+                "Nautical dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 05:14 CET")
     }
 
-    @Test("Summer solstice civil dawn at Oldenburg is ≈ 04:08 CEST")
-    func civilDawnAtSummerSolstice() throws {
-        let actual = try civilTwilightComponents(year: 2026, month: 6, day: 21, isDawn: true)
-        let expected = 4 * 60 + 8
+    @Test("Spring equinox nautical dusk at Oldenburg is ≈ 19:59 CET")
+    func nauticalDuskAtSpringEquinox() throws {
+        let actual = try nauticalTwilightComponents(year: 2026, month: 3, day: 20, isDawn: false)
+        let expected = 19 * 60 + 59
         #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
-                "Civil dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 04:08 CEST")
+                "Nautical dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 19:59 CET")
     }
 
-    @Test("Summer solstice civil dusk at Oldenburg is ≈ 22:47 CEST")
-    func civilDuskAtSummerSolstice() throws {
-        let actual = try civilTwilightComponents(year: 2026, month: 6, day: 21, isDawn: false)
-        let expected = 22 * 60 + 47
+    @Test("Winter solstice nautical dawn at Oldenburg is ≈ 07:06 CET")
+    func nauticalDawnAtWinterSolstice() throws {
+        let actual = try nauticalTwilightComponents(year: 2026, month: 12, day: 21, isDawn: true)
+        let expected = 7 * 60 + 6
         #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
-                "Civil dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 22:47 CEST")
+                "Nautical dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 07:06 CET")
     }
 
-    @Test("Winter solstice civil dawn at Oldenburg is ≈ 07:53 CET")
-    func civilDawnAtWinterSolstice() throws {
-        let actual = try civilTwilightComponents(year: 2026, month: 12, day: 21, isDawn: true)
-        let expected = 7 * 60 + 53
+    @Test("Winter solstice nautical dusk at Oldenburg is ≈ 17:39 CET")
+    func nauticalDuskAtWinterSolstice() throws {
+        let actual = try nauticalTwilightComponents(year: 2026, month: 12, day: 21, isDawn: false)
+        let expected = 17 * 60 + 39
         #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
-                "Civil dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 07:53 CET")
+                "Nautical dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 17:39 CET")
     }
 
-    @Test("Winter solstice civil dusk at Oldenburg is ≈ 16:52 CET")
-    func civilDuskAtWinterSolstice() throws {
-        let actual = try civilTwilightComponents(year: 2026, month: 12, day: 21, isDawn: false)
-        let expected = 16 * 60 + 52
-        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
-                "Civil dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 16:52 CET")
-    }
-
-    @Test("Civil twilight duration matches astronomy at 53°N",
+    @Test("Nautical twilight duration matches astronomy at 53°N",
           arguments: [
-            // (month, day, expected duration in minutes ±2 min tolerance)
-            (3, 20, 35),  // equinox: ≈ 34.6 min
-            (6, 21, 52),  // summer solstice: ≈ 52.3 min
-            (9, 22, 35),  // autumn equinox: ≈ 34.6 min
-            (12, 21, 42)  // winter solstice: ≈ 42.6 min
+            // (month, day, expected duration in minutes ±3 min tolerance)
+            (3, 20, 76),  // equinox: ≈ 75.7 min
+            (12, 21, 88)  // winter solstice: ≈ 87.9 min
           ])
-    func civilTwilightDuration(month: Int, day: Int, expectedMinutes: Int) throws {
+    func nauticalTwilightDuration(month: Int, day: Int, expectedMinutes: Int) throws {
         var calendar = Calendar.current
         calendar.timeZone = timeZone
         let refDate = try date(year: 2026, month: month, day: day, hour: 12, minute: 0)
@@ -197,11 +181,11 @@ struct SunComparisonTests {
 
         let sunrise = try #require(schedule.sunrise)
         let sunset = try #require(schedule.sunset)
-        let civilDawn = try #require(schedule.civilDawn)
-        let civilDusk = try #require(schedule.civilDusk)
+        let nauticalDawn = try #require(schedule.nauticalDawn)
+        let nauticalDusk = try #require(schedule.nauticalDusk)
 
-        let dawnDurationMin = sunrise.date.timeIntervalSince(civilDawn.date) / 60
-        let duskDurationMin = civilDusk.date.timeIntervalSince(sunset.date) / 60
+        let dawnDurationMin = sunrise.date.timeIntervalSince(nauticalDawn.date) / 60
+        let duskDurationMin = nauticalDusk.date.timeIntervalSince(sunset.date) / 60
 
         #expect(abs(dawnDurationMin - Double(expectedMinutes)) <= 3,
                 "Dawn duration \(dawnDurationMin) min differs from expected \(expectedMinutes) ±3 min")
@@ -209,29 +193,23 @@ struct SunComparisonTests {
                 "Dusk duration \(duskDurationMin) min differs from expected \(expectedMinutes) ±3 min")
     }
 
-    @Test("Civil dawn always precedes sunrise across the year")
-    func civilDawnAlwaysBeforeSunrise() throws {
-        var calendar = Calendar.current
-        calendar.timeZone = timeZone
-        for month in [1, 3, 5, 7, 9, 11] {
-            let refDate = try date(year: 2026, month: month, day: 15, hour: 12, minute: 0)
-            let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
-            let sunrise = try #require(schedule.sunrise)
-            let civilDawn = try #require(schedule.civilDawn)
-            #expect(civilDawn.date < sunrise.date, "Civil dawn must precede sunrise (month \(month))")
-        }
-    }
+    /// At 53°N the sun reaches a minimum elevation of about −13.5° around the
+    /// summer solstice — only just below the −12° nautical-twilight threshold.
+    /// `Sun.schedule` therefore reports a "dusk" time wrapped past midnight.
+    /// `getSunData(for:)` is responsible for filtering those wrap-arounds out
+    /// so the brightness curve falls back to civil twilight.
+    @Test("Summer solstice: nautical dusk wrap is rejected by getSunData")
+    func nauticalDuskWrapAtSummerSolsticeIsFiltered() throws {
+        let summerDate = try date(year: 2026, month: 6, day: 21, hour: 12, minute: 0)
+        let sunData = try #require(getSunData(for: summerDate))
 
-    @Test("Civil dusk always follows sunset across the year")
-    func civilDuskAlwaysAfterSunset() throws {
-        var calendar = Calendar.current
-        calendar.timeZone = timeZone
-        for month in [1, 3, 5, 7, 9, 11] {
-            let refDate = try date(year: 2026, month: month, day: 15, hour: 12, minute: 0)
-            let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
-            let sunset = try #require(schedule.sunset)
-            let civilDusk = try #require(schedule.civilDusk)
-            #expect(civilDusk.date > sunset.date, "Civil dusk must follow sunset (month \(month))")
+        // Either nil (filtered) or — in the unlikely case the algorithm
+        // returns it on the right side of midnight — strictly after sunset.
+        if let nauticalDusk = sunData.nauticalDusk {
+            #expect(nauticalDusk > sunData.sunset, "Nautical dusk \(nauticalDusk) must be after sunset \(sunData.sunset)")
+        }
+        if let nauticalDawn = sunData.nauticalDawn {
+            #expect(nauticalDawn < sunData.sunrise, "Nautical dawn \(nauticalDawn) must be before sunrise \(sunData.sunrise)")
         }
     }
 }

--- a/Tests/HomeAutomationKitTests/HelperTests/SunComparisonTests.swift
+++ b/Tests/HomeAutomationKitTests/HelperTests/SunComparisonTests.swift
@@ -112,4 +112,126 @@ struct SunComparisonTests {
         let testDate = try date(year: 2026, month: 3, day: 20, hour: 22, minute: 0)
         #expect(Sun.sunsetElevation(for: testDate, latitude: latitude, longitude: longitude, timeZone: timeZone) == .below)
     }
+
+    // MARK: - Civil twilight (sun at zenith 96°, i.e. 6° below the horizon)
+    //
+    // Reference values for Oldenburg (53.14°N, 8.21°E) come from standard
+    // astronomical tables (NOAA Solar Calculator algorithm, which is what
+    // `Sun.swift` implements). Tolerances are ±5 min to absorb rounding and
+    // small algorithmic differences while still failing on regressions.
+
+    private func civilTwilightComponents(year: Int, month: Int, day: Int, isDawn: Bool) throws -> (hour: Int, minute: Int) {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        let refDate = try date(year: year, month: month, day: day, hour: 12, minute: 0)
+        let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
+        let position = try #require(isDawn ? schedule.civilDawn : schedule.civilDusk)
+        return (calendar.component(.hour, from: position.date), calendar.component(.minute, from: position.date))
+    }
+
+    private func minutesSinceMidnight(_ components: (hour: Int, minute: Int)) -> Int {
+        components.hour * 60 + components.minute
+    }
+
+    @Test("Spring equinox civil dawn at Oldenburg is ≈ 05:56 CET")
+    func civilDawnAtSpringEquinox() throws {
+        let actual = try civilTwilightComponents(year: 2026, month: 3, day: 20, isDawn: true)
+        let expected = 5 * 60 + 56
+        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
+                "Civil dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 05:56 CET")
+    }
+
+    @Test("Spring equinox civil dusk at Oldenburg is ≈ 19:17 CET")
+    func civilDuskAtSpringEquinox() throws {
+        let actual = try civilTwilightComponents(year: 2026, month: 3, day: 20, isDawn: false)
+        let expected = 19 * 60 + 17
+        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
+                "Civil dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 19:17 CET")
+    }
+
+    @Test("Summer solstice civil dawn at Oldenburg is ≈ 04:08 CEST")
+    func civilDawnAtSummerSolstice() throws {
+        let actual = try civilTwilightComponents(year: 2026, month: 6, day: 21, isDawn: true)
+        let expected = 4 * 60 + 8
+        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
+                "Civil dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 04:08 CEST")
+    }
+
+    @Test("Summer solstice civil dusk at Oldenburg is ≈ 22:47 CEST")
+    func civilDuskAtSummerSolstice() throws {
+        let actual = try civilTwilightComponents(year: 2026, month: 6, day: 21, isDawn: false)
+        let expected = 22 * 60 + 47
+        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
+                "Civil dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 22:47 CEST")
+    }
+
+    @Test("Winter solstice civil dawn at Oldenburg is ≈ 07:53 CET")
+    func civilDawnAtWinterSolstice() throws {
+        let actual = try civilTwilightComponents(year: 2026, month: 12, day: 21, isDawn: true)
+        let expected = 7 * 60 + 53
+        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
+                "Civil dawn was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 07:53 CET")
+    }
+
+    @Test("Winter solstice civil dusk at Oldenburg is ≈ 16:52 CET")
+    func civilDuskAtWinterSolstice() throws {
+        let actual = try civilTwilightComponents(year: 2026, month: 12, day: 21, isDawn: false)
+        let expected = 16 * 60 + 52
+        #expect(abs(minutesSinceMidnight(actual) - expected) <= 5,
+                "Civil dusk was \(actual.hour):\(String(format: "%02d", actual.minute)), expected ≈ 16:52 CET")
+    }
+
+    @Test("Civil twilight duration matches astronomy at 53°N",
+          arguments: [
+            // (month, day, expected duration in minutes ±2 min tolerance)
+            (3, 20, 35),  // equinox: ≈ 34.6 min
+            (6, 21, 52),  // summer solstice: ≈ 52.3 min
+            (9, 22, 35),  // autumn equinox: ≈ 34.6 min
+            (12, 21, 42)  // winter solstice: ≈ 42.6 min
+          ])
+    func civilTwilightDuration(month: Int, day: Int, expectedMinutes: Int) throws {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        let refDate = try date(year: 2026, month: month, day: day, hour: 12, minute: 0)
+        let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
+
+        let sunrise = try #require(schedule.sunrise)
+        let sunset = try #require(schedule.sunset)
+        let civilDawn = try #require(schedule.civilDawn)
+        let civilDusk = try #require(schedule.civilDusk)
+
+        let dawnDurationMin = sunrise.date.timeIntervalSince(civilDawn.date) / 60
+        let duskDurationMin = civilDusk.date.timeIntervalSince(sunset.date) / 60
+
+        #expect(abs(dawnDurationMin - Double(expectedMinutes)) <= 3,
+                "Dawn duration \(dawnDurationMin) min differs from expected \(expectedMinutes) ±3 min")
+        #expect(abs(duskDurationMin - Double(expectedMinutes)) <= 3,
+                "Dusk duration \(duskDurationMin) min differs from expected \(expectedMinutes) ±3 min")
+    }
+
+    @Test("Civil dawn always precedes sunrise across the year")
+    func civilDawnAlwaysBeforeSunrise() throws {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        for month in [1, 3, 5, 7, 9, 11] {
+            let refDate = try date(year: 2026, month: month, day: 15, hour: 12, minute: 0)
+            let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
+            let sunrise = try #require(schedule.sunrise)
+            let civilDawn = try #require(schedule.civilDawn)
+            #expect(civilDawn.date < sunrise.date, "Civil dawn must precede sunrise (month \(month))")
+        }
+    }
+
+    @Test("Civil dusk always follows sunset across the year")
+    func civilDuskAlwaysAfterSunset() throws {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+        for month in [1, 3, 5, 7, 9, 11] {
+            let refDate = try date(year: 2026, month: month, day: 15, hour: 12, minute: 0)
+            let schedule = try #require(Sun.schedule(latitude: latitude, longitude: longitude, date: refDate, calendar: calendar, timeZone: timeZone))
+            let sunset = try #require(schedule.sunset)
+            let civilDusk = try #require(schedule.civilDusk)
+            #expect(civilDusk.date > sunset.date, "Civil dusk must follow sunset (month \(month))")
+        }
+    }
 }

--- a/Tests/SharedTests/ColorTempRGBTests.swift
+++ b/Tests/SharedTests/ColorTempRGBTests.swift
@@ -150,20 +150,55 @@ final class ColorTempRGBTests: XCTestCase {
 
     // MARK: - Color Temperature Tests
 
-    func testColorTemperatureNormalized_WarmWhite() {
-        let rgb = componentsForColorTemperature(normalzied: 0.0) // 2000K - warm
+    func testColorTemperatureNormalized_Warm() {
+        let rgb = componentsForColorTemperature(normalized: 0.0) // 2000K (500 mired)
 
-        // Warm white should have more red than blue
-        XCTAssertGreaterThan(rgb.red, rgb.blue, "Warm white should have more red than blue")
-        XCTAssertGreaterThan(rgb.red, 0.9, "Warm white should have high red component")
+        XCTAssertGreaterThan(rgb.red, rgb.blue, "Warm light should have more red than blue")
+        XCTAssertGreaterThan(rgb.red, 0.9, "Warm light should have a high red component")
+        XCTAssertLessThan(rgb.blue, 0.2, "Warm light should have a very low blue component")
     }
 
-    func testColorTemperatureNormalized_CoolWhite() {
-        let rgb = componentsForColorTemperature(normalzied: 1.0) // 4000K - neutral/cool
+    func testColorTemperatureNormalized_Cool() {
+        let rgb = componentsForColorTemperature(normalized: 1.0) // ≈ 6494K (154 mired)
 
-        // At 4000K, still has high red but more blue than warm white
-        XCTAssertGreaterThan(rgb.red, 0.9, "4000K should still have high red")
-        XCTAssertGreaterThan(rgb.blue, 0.6, "4000K should have decent blue component")
+        // 6500K approximates daylight white: high red AND high blue.
+        XCTAssertGreaterThan(rgb.red, 0.9, "Cool daylight should still have a high red component")
+        XCTAssertGreaterThan(rgb.blue, 0.9, "Cool daylight should have a high blue component")
+        XCTAssertGreaterThan(rgb.green, 0.9, "Cool daylight should have a high green component")
+    }
+
+    /// Guards that the cool end of the normalized range reaches true daylight
+    /// (low-saturation white), keeping the RGB path visually aligned with the
+    /// native HomeKit color-temperature characteristic.
+    func testColorTemperatureNormalized_RangeReachesDaylight() {
+        let cool = componentsForColorTemperature(normalized: 1.0)
+
+        // Saturation should be very low at true daylight — nearly neutral white.
+        let hsv = HAModels.hsv(from: cool)
+        XCTAssertLessThan(hsv.s, 0.15, "Cool end should produce near-neutral white, got saturation \(hsv.s)")
+    }
+
+    /// The normalized scale runs linearly in *mired*, matching the native
+    /// HomeKit color-temperature characteristic. This keeps visual parity
+    /// between RGB and native bulbs when the same normalized input is used.
+    func testColorTemperatureNormalized_MiredLinearMapping() {
+        // mired at value = 0.5 is the midpoint of 154…500, i.e. 327 → ≈ 3058K.
+        let midpoint = componentsForColorTemperature(normalized: 0.5)
+        let expected = componentsForColorTemperature(temperatureInKelvin: 1_000_000 / 327)
+
+        XCTAssertEqual(midpoint.red, expected.red, accuracy: 0.01)
+        XCTAssertEqual(midpoint.green, expected.green, accuracy: 0.01)
+        XCTAssertEqual(midpoint.blue, expected.blue, accuracy: 0.01)
+    }
+
+    func testColorTemperatureNormalized_MonotonicBlueIncrease() {
+        // Moving from warm (0) to cool (1), blue should increase monotonically.
+        let samples = stride(from: Float(0), through: Float(1), by: 0.1).map {
+            componentsForColorTemperature(normalized: $0).blue
+        }
+        for (prev, next) in zip(samples, samples.dropFirst()) {
+            XCTAssertLessThanOrEqual(prev, next + 0.0001, "Blue component must not decrease as color temperature rises")
+        }
     }
 
     func testColorTemperatureKelvin_2700K() {


### PR DESCRIPTION
## Summary
- **Reproduces a regression spotted at runtime**: with the previous ramp the lights stayed at 100 % until the moment of sunset and only began dimming afterwards (e.g. 100 % at 20:30 with sunset at 20:32). Perceived daylight already drops noticeably during the golden hour before sunset; the new curve eases down through that window.
- **Cosine ramps are now centred on sunrise/sunset** with a half-width derived from twilight. Sunrise/sunset sit at the 0.5 point, the twilight endpoints at 0.
- **Nautical twilight (sun 12° below horizon) is the new preferred ramp anchor.** ≈ 75 min wide at 53°N around the equinox, ≈ 88 min mid-winter. Two minutes before sunset the curve now reports ≈ 0.5 instead of 1.0.
- **Three-tier fallback chain**: nautical → civil → fixed 43 min. ` getSunData(for:)` rejects twilight times that wrap past midnight (e.g. nautical dusk at 53°N in mid-summer) so the next-best definition takes over automatically.

## Concrete numbers (Oldenburg, sunset 20:32, mid-April)

| Time | Old curve | This PR |
|-----:|----------:|--------:|
| 20:30 | 100 % | **51 %** |
| 20:32 (sunset) | 100 % | 50 % |
| 20:49 | 66 % | **33 %** |
| 21:09 (civil dusk) | 0 % (= night-floor 10 %) | 17 % |
| 21:50 (nautical dusk) | 0 % | 0 % (= night-floor) |

## Test plan
- [x] `swift build`
- [x] `swift test --filter \"CircadianTests|SunComparisonTests\"` — 49 tests pass
  - 7 new nautical-twilight assertions in `SunComparisonTests` (equinox + winter-solstice clock times, duration check, summer-solstice wrap-around filter)
  - Updated brightness curve assertions: sunrise/sunset = 0.5, nautical dawn/dusk = 0, peak boundaries at sunrise ± nautical-twilight, civil-fallback path explicitly tested
- [x] `swiftlint` clean on changed files (remaining warnings are pre-existing on `h`/`m` variable names)
- [ ] CI: SPM build & test, iOS app builds, Docker build