### PR TITLE
Fix serial event processing bottleneck using withDiscardingTaskGroup

### DIFF
--- a/Sources/HAApplicationLayer/AutomationService.swift
+++ b/Sources/HAApplicationLayer/AutomationService.swift
@@ -22,7 +22,7 @@ public actor AutomationService {
     public func trigger(with event: HomeEvent) async {
         let automations = await getAutomations()
 
-        await withTaskGroup(of: Void.self) { group in
+        await withDiscardingTaskGroup { group in
             for automation in automations where automation.isActive {
                 group.addTask {
                     do {
@@ -31,8 +31,7 @@ public actor AutomationService {
                         }
 
                         self.log.info("Running automation \(automation.name)")
-                        let task = Task { [weak self] in
-                            guard let self else { return }
+                        let task = Task {
                             do {
                                 try await automation.execute(using: self.homeManager)
                             } catch is CancellationError {

--- a/Sources/Server/Jobs/EventProcessingJob.swift
+++ b/Sources/Server/Jobs/EventProcessingJob.swift
@@ -16,20 +16,16 @@ struct HomeEventProcessingJob: Job, Log {
     let homeManager: any HomeManagable
 
     func run() async {
-        // This is where you would send the email
-        for await event in homeEventsStream {
-            log.debug("trigger automation with \(event.description)")
-
-            // add item to history
-            switch event {
-            case .change(let item):
-                await homeManager.addEntityHistory(item)
-            case .time, .sunset, .sunrise:
-                break
+        await withDiscardingTaskGroup { group in
+            for await event in homeEventsStream {
+                log.debug("trigger automation with \(event.description)")
+                group.addTask {
+                    if case .change(let item) = event {
+                        await self.homeManager.addEntityHistory(item)
+                    }
+                    await self.automationService.trigger(with: event)
+                }
             }
-
-            // perform automation
-            await automationService.trigger(with: event)
         }
     }
 }

--- a/Sources/Server/Jobs/EventProcessingJob.swift
+++ b/Sources/Server/Jobs/EventProcessingJob.swift
@@ -20,9 +20,12 @@ struct HomeEventProcessingJob: Job, Log {
             for await event in homeEventsStream {
                 log.debug("trigger automation with \(event.description)")
                 group.addTask {
+                    // add item to history
                     if case .change(let item) = event {
                         await self.homeManager.addEntityHistory(item)
                     }
+
+                    // perform automation
                     await self.automationService.trigger(with: event)
                 }
             }


### PR DESCRIPTION
Closes #173

## Problem

Under high sensor load (CO2 sensor every 10s, active motion sensors), the `HomeEventReceiver` distributed actor backed up. The FlowKit Adapter accumulated 15s timeouts, and the `/health` endpoint hung >10s causing Docker to mark the container `unhealthy`.

Root cause: `EventProcessingJob.run()` processed events **serially** — it awaited `trigger()` before pulling the next event. `trigger()` used `withTaskGroup(of: Void.self)` which blocked until all `shouldTrigger()` evaluations completed.

## Changes

### `EventProcessingJob.swift`

Replaced the serial `for await` loop body with `withDiscardingTaskGroup`:

```swift
// BEFORE — serial, blocks on every event
for await event in homeEventsStream {
    await homeManager.addEntityHistory(item)
    await automationService.trigger(with: event)  // blocks 5+ seconds
}

// AFTER — concurrent, loop drains immediately
await withDiscardingTaskGroup { group in
    for await event in homeEventsStream {
        group.addTask {
            await self.homeManager.addEntityHistory(item)
            await self.automationService.trigger(with: event)
        }
    }
}
```

`group.addTask` is synchronous — the `for await` loop continues immediately to the next event without waiting.

### `AutomationService.swift`

- Replaced `withTaskGroup(of: Void.self)` → `withDiscardingTaskGroup` (no result buffering, more efficient)
- Removed `[weak self]` from `Task { }` spawned inside the actor method — in Swift 6, `Task { }` inside an actor context holds a strong reference to the actor; `[weak self]` was an antipattern that could cause the task body to exit early

## Why `withDiscardingTaskGroup` over fire-and-forget `Task { }`

| | `Task { await trigger() }` | `withDiscardingTaskGroup` |
|---|---|---|
| Backpressure | ❌ unbounded task accumulation | ✅ natural via task group |
| Cancellation | ❌ propagation lost | ✅ structured |
| Memory | ⚠️ grows under load | ✅ no result buffer |
| Swift 6 | ✅ | ✅ |

## Test plan

- [ ] `swift build` — compiles cleanly ✅ (verified)
- [ ] Deploy via `swift run` in config repo
- [ ] Monitor FlowKit logs under sensor load: no `RemoteCallError(timedOut...)` 
- [ ] `docker inspect ... --format='{{.State.Health.Status}}'` stays `healthy`
- [ ] Server logs: automations still fire (`Running automation ...`)