### PR TITLE
Fix cluster-split "Server Down": server-only leader with self-healing

### DIFF
--- a/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
+++ b/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
@@ -6,6 +6,7 @@
 //
 
 import Adapter
+import Foundation
 import HAImplementations
 import HAModels
 import Shared
@@ -46,15 +47,34 @@ struct FlowKitAdapter: App, Log {
                 // do not start run loop when running in preview canvas
                 guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return }
 
+                // Tear down a previously-created system first (e.g. serverAddress changed) so its
+                // cluster node, background tasks and bound port are released before creating a new one.
+                await teardownActorSystem()
+
                 try? await Task.sleep(for: .seconds(1))
                 await initializeActorSystem()
             }
         }
     }
 
+    private func teardownActorSystem() async {
+        statusObservationTask?.cancel()
+        statusObservationTask = nil
+        entityObservationTask?.cancel()
+        entityObservationTask = nil
+        if let actorSystem {
+            await actorSystem.shutdown()
+            self.actorSystem = nil
+        }
+    }
+
     private func initializeActorSystem() async {
-        // Initialize with configured server address
-        let system = await CustomActorSystem(role: .homeKitAdapter(serverAddress: serverAddress))
+        // Initialize with configured server address.
+        // onDown: a lost connection that does not recover within the grace period restarts the app
+        // (launchctl KeepAlive) with a fresh node UID → clean re-handshake with the server.
+        let system = await CustomActorSystem(role: .homeKitAdapter(serverAddress: serverAddress), onDown: {
+            exit(1)
+        })
         self.actorSystem = system
 
         let (entityStream, entityStreamContinuation) = AsyncStream.makeStream(

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a43ecd95cb233e253ffd3c04d42e48ffe5295ccfeb3e16a974bd823a612717ed",
+  "originHash" : "2133af98c9362e1781c090dc098a13c92dbc9818e172528372c1c4dc5b821bd2",
   "pins" : [
     {
       "identity" : "apns",
@@ -555,8 +555,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
-        "version" : "1.7.0"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -185,6 +185,13 @@ let package = Package(
                 "HAModels"
             ],
             path: "Tests/ServerTests"
+        ),
+        .testTarget(
+            name: "SharedDistributedClusterTests",
+            dependencies: [
+                "SharedDistributedCluster",
+                .product(name: "DistributedCluster", package: "swift-distributed-actors"),
+            ]
         )
     ]
 )

--- a/Sources/Server/Jobs/EventProcessingJob.swift
+++ b/Sources/Server/Jobs/EventProcessingJob.swift
@@ -16,19 +16,19 @@ struct HomeEventProcessingJob: Job, Log {
     let homeManager: any HomeManagable
 
     func run() async {
-        await withDiscardingTaskGroup { group in
-            for await event in homeEventsStream {
-                log.debug("trigger automation with \(event.description)")
-                group.addTask {
-                    // add item to history
-                    if case .change(let item) = event {
-                        await self.homeManager.addEntityHistory(item)
-                    }
+        // Serial processing preserves event ordering (history writes and automation triggering).
+        // `trigger(with:)` returns quickly — long-running `execute()` runs in the background inside
+        // AutomationService — so a slow automation does not stall the loop.
+        for await event in homeEventsStream {
+            log.debug("trigger automation with \(event.description)")
 
-                    // perform automation
-                    await self.automationService.trigger(with: event)
-                }
+            // add item to history
+            if case .change(let item) = event {
+                await homeManager.addEntityHistory(item)
             }
+
+            // perform automation
+            await automationService.trigger(with: event)
         }
     }
 }

--- a/Sources/Server/configure.swift
+++ b/Sources/Server/configure.swift
@@ -193,14 +193,11 @@ public func configure(_ app: Application) async throws {
 
     // MARK: - actor system setup
 
-    // When the FlowKit Adapter restarts (e.g. due to HomeKit HMErrorDomain Code=74 errors),
-    // the new adapter instance sends .restInPeace to the server via SWIM protocol, marking
-    // the server's cluster node as .down. After this, the server cannot communicate with the
-    // adapter anymore — all HomeKit commands fail. This state is unrecoverable without a
-    // process restart. The onDown closure terminates the process so Docker can restart the container.
-    let actorSystem = await CustomActorSystem(role: .server, onDown: {
-        exit(1)
-    })
+    // The server is the cluster's sole leader (see CustomActorSystem.makeClusterSettings): with a
+    // single reachable member it self-elects, so it can promote a (re)joining adapter to .up and
+    // down dead adapter nodes. It therefore recovers from adapter restarts on its own and must
+    // NEVER terminate — hence no onDown handler. Recovery on the adapter side is its own restart.
+    let actorSystem = await CustomActorSystem(role: .server)
     app.customActorSystem = actorSystem
     let eventReceiver = await actorSystem.makeLocalActor(actorId: .homeEventReceiver) { system in
         HomeEventReceiver(continuation: app.homeEventsContinuation, actorSystem: system)

--- a/Sources/Server/routes.swift
+++ b/Sources/Server/routes.swift
@@ -23,14 +23,31 @@ func routes(_ app: Application) throws {
         guard let sql = req.db as? any SQLDatabase else {
             throw Abort(.internalServerError, reason: "Database does not support SQL queries")
         }
-        try await sql.raw("SELECT 1").run()
+        let system = req.application.customActorSystem
 
-        let connectionStatus = await req.application.customActorSystem.latestConnectionStatus
-        guard connectionStatus == .up else {
-            throw Abort(.serviceUnavailable, reason: "Adapter connection status: \(String(describing: connectionStatus))")
+        // Race the health checks against a hard timeout so the Docker healthcheck always gets a
+        // fast, definitive answer (503 peer-not-up / 504 timeout) instead of hanging.
+        return try await withThrowingTaskGroup(of: HTTPStatus.self) { group in
+            group.addTask {
+                try await sql.raw("SELECT 1").run()
+
+                let connectionStatus = await system.latestConnectionStatus
+                guard connectionStatus == .up else {
+                    throw Abort(.serviceUnavailable, reason: "Adapter connection status: \(String(describing: connectionStatus))")
+                }
+                return .ok
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw Abort(.gatewayTimeout, reason: "Health check timed out")
+            }
+
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw Abort(.internalServerError)
+            }
+            return result
         }
-
-        return .ok
     }
 
     authenticatedRoutes.get("config") { req in

--- a/Sources/SharedDistributedCluster/CustomActorSystem.swift
+++ b/Sources/SharedDistributedCluster/CustomActorSystem.swift
@@ -5,7 +5,6 @@
 //  Created by Julian Kahnert on 06.02.25.
 //
 
-import AsyncAlgorithms
 import Distributed
 import DistributedCluster
 import Foundation
@@ -14,13 +13,13 @@ import ServiceDiscovery
 
 typealias DefaultDistributedActorSystem = ClusterSystem
 
-/// Connection status of the distributed actor system
-public enum ConnectionStatus: Sendable {
-    /// Successfully connected
+/// Connection status of the distributed actor system, as seen from the local node towards its peer.
+public enum ConnectionStatus: Sendable, Equatable {
+    /// A reachable peer is `.up` — the cluster is healthy.
     case up
-    /// Attempting to connect
+    /// No peer yet, or a reachable peer is still handshaking / coming up.
     case joining
-    /// Connection failed/lost
+    /// A known peer is down / removed / unreachable.
     case error
 }
 
@@ -59,113 +58,251 @@ public actor CustomActorSystem {
     private static let log = Logger(label: "CustomActorSystem")
     private let systemRole: SystemRole
     private let actorSystem: ClusterSystem
-    private var reconnectionTask: Task<Void, Error>?
-    private var currentConnectionStatus: ConnectionStatus?
-    private var _connectionStatus: (any AsyncSequence<ConnectionStatus, Never> & Sendable)!
+    private let onDown: (@Sendable () -> Void)?
 
-    /// Stream of connection status changes derived from cluster events.
-    /// Shared sequence created once during initialization.
-    public var connectionStatus: any AsyncSequence<ConnectionStatus, Never> & Sendable {
-        _connectionStatus
-    }
+    private var reconnectionTask: Task<Void, Never>?
+    private var statusTask: Task<Void, Never>?
+    private var graceTask: Task<Void, Never>?
+
+    /// The most recent connection status, or nil if no cluster event has been processed yet.
+    private var currentConnectionStatus: ConnectionStatus?
+    /// Whether a reachable peer ever reached `.up`. Gates the `onDown` recovery so we don't
+    /// terminate during the initial boot (before the peer connects for the first time).
+    private var everConnected = false
+    /// Live subscribers to `connectionStatus`. Each gets the current value first, then live updates.
+    private var subscribers: [UUID: AsyncStream<ConnectionStatus>.Continuation] = [:]
 
     /// Returns the most recent connection status, or nil if no event has been received yet.
     public var latestConnectionStatus: ConnectionStatus? {
         currentConnectionStatus
     }
 
+    /// A fresh stream of connection status changes. The stream is seeded with the *current* value
+    /// (so late subscribers never miss the latest state — unlike a plain broadcast), followed by
+    /// live updates.
+    public var connectionStatus: AsyncStream<ConnectionStatus> {
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: ConnectionStatus.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        if let current = currentConnectionStatus {
+            continuation.yield(current)
+        }
+        let id = UUID()
+        subscribers[id] = continuation
+        continuation.onTermination = { [weak self] _ in
+            Task { await self?.removeSubscriber(id) }
+        }
+        return stream
+    }
+
     /// - Parameters:
     ///   - role: The system role (server or adapter)
-    ///   - onDown: Optional closure called when the connection is lost and does not recover within 60s.
-    ///     The built-in `onDownAction: .gracefulShutdown` only shuts down the actor system, not the
-    ///     hosting process. This closure allows the caller to terminate the entire process (e.g. `exit(1)`).
+    ///   - onDown: Optional closure called when the connection to the peer is lost and does not
+    ///     recover within a grace period (and the peer had connected at least once before).
+    ///     Used by the **adapter** to `exit(1)` so launchctl restarts it with a fresh node UID.
+    ///     The **server** passes `nil` — it never terminates; it stays alive and heals as the
+    ///     cluster leader.
     public init(role: SystemRole, onDown: (@Sendable () -> Void)? = nil) async {
         self.systemRole = role
+        self.onDown = onDown
 
-        // Setup cluster settings
-        var settings = ClusterSystemSettings(name: role.name, host: role.host, port: role.port)
-
-        // Configure discovery based on role
-        switch role {
-        case .server:
-            // Server: No discovery, only accept connections
-            settings.discovery = nil
-
-        case .homeKitAdapter(serverAddress: let address):
-            // Adapter: Discover specific server
-            let endpoint = Cluster.Endpoint(host: address.host, port: address.port)
-            settings.discovery = ServiceDiscoverySettings(static: [endpoint])
-        }
-
-        settings.remoteCall.defaultTimeout = .seconds(15)
-        settings.logging.logLevel = .warning
-
-        // We handle down events ourselves via the onDown closure instead of using the
-        // built-in .gracefulShutdown, which only shuts down the actor system but not
-        // the hosting process (Vapor server). We need a full process exit so Docker
-        // can restart the container.
-        if case .server = role {
-            settings.onDownAction = .none
-        }
-
+        let settings = Self.makeClusterSettings(role: role)
         actorSystem = await ClusterSystem(role.name, settings: settings)
 
-        // Create shared connection status sequence once using compactMap + share
-        _connectionStatus = actorSystem.cluster.events
-            .compactMap { event in
-                Self.mapEventToConnectionStatus(event: event)
-            }
-            .share()
+        // Derive connection status from cluster events (membership + reachability).
+        startStatusTask()
+
+        // Only the adapter actively (re)connects to the server.
+        if case .homeKitAdapter = role {
+            tryReconnectIfNeededInBackground()
+        }
+    }
+
+    // MARK: - Cluster settings
+
+    /// Builds the cluster settings for a given role. Pure & deterministic so it can be unit-tested
+    /// (leader selection / downing behavior).
+    ///
+    /// Key invariants:
+    /// - **Only the server may ever become leader.** The server self-elects with a single reachable
+    ///   member (`minNumberOfMembers: 1`), so it can promote a (re)joining adapter to `.up` and down
+    ///   dead members — letting the cluster self-heal. The adapter uses `.none` and therefore never
+    ///   becomes leader, which prevents a mutual-down split-brain.
+    /// - Downing is left enabled (it only fires while a leader exists, i.e. on the server) but with a
+    ///   tolerant timeout so brief blips don't evict the peer.
+    /// - `onDownAction = .none` on both: we never let the library silently shut the system down;
+    ///   recovery is handled explicitly (server stays alive as leader, adapter reconnects/restarts).
+    /// - Parameters:
+    ///   - host/port: optional bind overrides (used by tests to avoid the fixed production ports).
+    public static func makeClusterSettings(role: SystemRole, host: String? = nil, port: Int? = nil) -> ClusterSystemSettings {
+        var settings = ClusterSystemSettings(name: role.name, host: host ?? role.host, port: port ?? role.port)
 
         switch role {
-        case .homeKitAdapter:
-            tryReconnectIfNeededInBackground()
-        default:
-            break
+        case .server:
+            settings.discovery = nil
+            settings.autoLeaderElection = .lowestReachable(minNumberOfMembers: 1)
+
+            var downing = TimeoutBasedDowningStrategySettings.default
+            downing.downUnreachableMembersAfter = .seconds(10)
+            settings.downingStrategy = .timeout(downing)
+
+        case .homeKitAdapter(serverAddress: let address):
+            let endpoint = Cluster.Endpoint(host: address.host, port: address.port)
+            settings.discovery = ServiceDiscoverySettings(static: [endpoint])
+            settings.autoLeaderElection = .none
         }
 
-        Task {
-            for await status in connectionStatus {
-                currentConnectionStatus = status
+        settings.onDownAction = .none
+        settings.remoteCall.defaultTimeout = .seconds(15)
+        settings.logging.logLevel = .warning
+        return settings
+    }
 
-                if status == .error, let onDown {
-                    Self.log.warning("Connection lost. Waiting 60s for reconnection...")
-                    try? await Task.sleep(for: .seconds(60))
+    // MARK: - Connection status derivation
 
-                    guard currentConnectionStatus != .up else {
-                        Self.log.info("Reconnected during grace period.")
-                        continue
-                    }
+    /// Pure decision function: maps the peer members' (status, reachability) to a connection status.
+    /// Kept free of `Cluster.Node`/`Cluster.Membership` construction so it is trivially unit-testable.
+    public static func decide(peers: [(status: Cluster.MemberStatus, reachability: Cluster.MemberReachability)]) -> ConnectionStatus {
+        if peers.isEmpty {
+            return .joining
+        }
+        if peers.contains(where: { $0.status == .up && $0.reachability == .reachable }) {
+            return .up
+        }
+        if peers.contains(where: { $0.reachability == .reachable && $0.status < .up }) {
+            return .joining
+        }
+        return .error
+    }
 
-                    Self.log.critical("Still disconnected after grace period. Calling onDown handler.")
-                    onDown()
-                }
+    /// Derives the connection status for `selfNode` from a full membership, considering only peers
+    /// (members other than self) and their reachability.
+    public static func connectionStatus(for membership: Cluster.Membership, selfNode: Cluster.Node) -> ConnectionStatus {
+        let peers = membership.members(atLeast: .joining)
+            .filter { $0.node != selfNode }
+            .map { (status: $0.status, reachability: $0.reachability) }
+        return decide(peers: peers)
+    }
+
+    private func startStatusTask() {
+        statusTask?.cancel()
+        statusTask = Task { [weak self] in
+            guard let self else { return }
+            let events = self.actorSystem.cluster.events
+            let selfNode = self.actorSystem.cluster.node
+            var membership = Cluster.Membership.empty
+            for await event in events {
+                Self.log.debug("Cluster event: \(event)")
+                _ = try? membership.apply(event: event)
+                let status = Self.connectionStatus(for: membership, selfNode: selfNode)
+                await self.handleStatus(status)
             }
         }
     }
 
-    /// Maps cluster events to connection status for the local node
-    /// - Parameters:
-    ///   - event: The cluster event to process
-    ///   - log: Logger instance for event logging
-    /// - Returns: Connection status if the event is relevant for the local node, nil otherwise
-    private static func mapEventToConnectionStatus(event: Cluster.Event) -> ConnectionStatus? {
-        log.info("Cluster event: \(event)")
+    private func handleStatus(_ status: ConnectionStatus) {
+        let changed = status != currentConnectionStatus
+        currentConnectionStatus = status
+        if changed {
+            Self.log.info("Connection status: \(status)")
+            for continuation in subscribers.values {
+                continuation.yield(status)
+            }
+        }
 
-        guard case Cluster.Event.membershipChange(let change) = event else { return nil }
-        switch change.member.status {
-        case .joining:
-            return .joining
-        case .up:
-            return .up
-        case .leaving:
-            return nil
-        case .down, .removed:
-            return .error
-        default:
-            return nil
+        // Recovery is opt-in via `onDown` (adapter only). The server passes nil and never terminates.
+        guard let onDown else { return }
+
+        if status == .up {
+            everConnected = true
+            graceTask?.cancel()
+            graceTask = nil
+            return
+        }
+
+        // Peer not up: start a single grace timer, but only after we had connected at least once,
+        // and only if one isn't already pending.
+        guard everConnected, graceTask == nil else { return }
+        graceTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(60))
+            guard let self else { return }
+            guard await self.currentConnectionStatus != .up else {
+                Self.log.info("Reconnected during grace period.")
+                return
+            }
+            Self.log.critical("Still disconnected after grace period. Calling onDown handler.")
+            onDown()
         }
     }
+
+    private func removeSubscriber(_ id: UUID) {
+        subscribers[id] = nil
+    }
+
+    // MARK: - Reconnection (adapter)
+
+    private func tryReconnectIfNeededInBackground() {
+        reconnectionTask?.cancel()
+        reconnectionTask = Task { [weak self] in
+            guard let self else { return }
+            guard case .homeKitAdapter(serverAddress: let address) = self.systemRole else { return }
+            let serverEndpoint = Cluster.Endpoint(host: address.host, port: address.port)
+
+            while !Task.isCancelled {
+                do {
+                    let snapshot = await self.actorSystem.cluster.membershipSnapshot
+                    let selfNode = self.actorSystem.cluster.node
+                    let status = Self.connectionStatus(for: snapshot, selfNode: selfNode)
+
+                    if status != .up {
+                        // Evict any stale server node lingering on the target endpoint (a previous
+                        // server instance with a now-dead UID). Manual `down(member:)` is leader-
+                        // independent, and targeting the specific *member* avoids downing the fresh
+                        // server that may already be (re)joining on the same host:port.
+                        let staleServerMembers = snapshot.members(atLeast: .joining).filter { member in
+                            member.node != selfNode
+                                && member.node.endpoint.host == serverEndpoint.host
+                                && member.node.endpoint.port == serverEndpoint.port
+                                && (member.reachability == .unreachable || member.status >= .down)
+                        }
+                        for member in staleServerMembers {
+                            Self.log.warning("Downing stale server member before rejoin: \(member)")
+                            self.actorSystem.cluster.down(member: member)
+                        }
+
+                        Self.log.info("Peer not up (\(status)) — (re)joining \(serverEndpoint)")
+                        _ = try await self.actorSystem.cluster.joined(endpoint: serverEndpoint, within: .seconds(30))
+                    }
+                } catch {
+                    Self.log.error("Reconnect attempt failed: \(error)")
+                }
+
+                try? await Task.sleep(for: .seconds(20))
+            }
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Cancels all background tasks and shuts down the underlying cluster system. Must be called when
+    /// the owner (e.g. the SwiftUI adapter app on server-address change) discards this instance, to
+    /// avoid leaking a cluster node, its tasks and its bound port.
+    public func shutdown() async {
+        reconnectionTask?.cancel()
+        statusTask?.cancel()
+        graceTask?.cancel()
+        reconnectionTask = nil
+        statusTask = nil
+        graceTask = nil
+        for continuation in subscribers.values {
+            continuation.finish()
+        }
+        subscribers.removeAll()
+        _ = try? actorSystem.shutdown()
+    }
+
+    // MARK: - Distributed actor helpers
 
     nonisolated public var endpointDescription: String {
         actorSystem.cluster.endpoint.description
@@ -188,37 +325,5 @@ public actor CustomActorSystem {
 
     public func listing<Guest>(of key: DistributedReception.Key<Guest>) async -> DistributedReception.GuestListing<Guest> where Guest: DistributedActor, Guest.ActorSystem == ClusterSystem {
         return await actorSystem.receptionist.listing(of: key)
-    }
-
-    private func tryReconnectIfNeededInBackground() {
-        reconnectionTask?.cancel()
-        reconnectionTask = Task { [weak actorSystem] in
-            while true {
-                guard let actorSystem else {
-                    assertionFailure()
-                    return
-                }
-
-                do {
-                    Self.log.debug("wait for node")
-                    try await actorSystem.cluster.waitFor(actorSystem.cluster.node, .up, within: .seconds(10))
-
-                    Self.log.info("get status: \(String(describing: currentConnectionStatus))")
-                    if currentConnectionStatus != .up,
-                       case .homeKitAdapter(serverAddress: let address) = systemRole {
-                        Self.log.warning("the node (\(systemRole) is up but there is no connection - joining again for 30s")
-//                        try await actorSystem.joined(host: address.host, port: address.port, within: .seconds(30))
-                        try await actorSystem.cluster.joined(endpoint: .init(host: address.host, port: address.port), within: .seconds(30))
-                    }
-                    Self.log.info("continue")
-                } catch {
-                    Self.log.error("Failed to initialize the actor system: \(error)")
-                }
-
-                Self.log.debug("waiting 20s")
-                try await Task.sleep(for: .seconds(20))
-                Self.log.debug("waiting 20s - finished")
-            }
-        }
     }
 }

--- a/Tests/SharedDistributedClusterTests/ClusterLeadershipTests.swift
+++ b/Tests/SharedDistributedClusterTests/ClusterLeadershipTests.swift
@@ -1,0 +1,88 @@
+//
+//  ClusterLeadershipTests.swift
+//  HomeAutomationKit
+//
+//  In-process cluster tests validating the leader-deadlock fix:
+//  - only the server may become leader (server: minNumberOfMembers 1, adapter: .none)
+//  - the server self-heals: promotes a (re)joining adapter to .up and downs a dead adapter.
+//
+//  These spin up real ClusterSystems on localhost test ports. They are timing-sensitive, so the
+//  suite is serialized and uses generous timeouts.
+//
+
+import DistributedCluster
+@testable import SharedDistributedCluster
+import Testing
+
+@Suite(.serialized)
+struct ClusterLeadershipTests {
+
+    private static func makeServer(port: Int) async -> ClusterSystem {
+        let settings = CustomActorSystem.makeClusterSettings(role: .server, host: "127.0.0.1", port: port)
+        return await ClusterSystem("server", settings: settings)
+    }
+
+    private static func makeAdapter(port: Int, serverPort: Int) async -> ClusterSystem {
+        let serverAddress = CustomActorSystem.Address(host: "127.0.0.1", port: serverPort)
+        let settings = CustomActorSystem.makeClusterSettings(
+            role: .homeKitAdapter(serverAddress: serverAddress),
+            host: "127.0.0.1",
+            port: port
+        )
+        return await ClusterSystem("homeKitAdapter", settings: settings)
+    }
+
+    @Test("Server alone self-elects as leader (minNumberOfMembers: 1)")
+    func serverAloneBecomesLeader() async throws {
+        let server = await Self.makeServer(port: 19_001)
+        defer { _ = try? server.shutdown() }
+
+        try await server.cluster.waitFor(server.cluster.node, .up, within: .seconds(30))
+
+        let membership = await server.cluster.membershipSnapshot
+        #expect(membership.leader?.node == server.cluster.node)
+    }
+
+    @Test("Adapter alone never becomes leader (autoLeaderElection: .none)")
+    func adapterAloneNeverBecomesLeader() async throws {
+        // Points at a server that isn't running — the adapter must still never elect itself.
+        let adapter = await Self.makeAdapter(port: 19_003, serverPort: 19_002)
+        defer { _ = try? adapter.shutdown() }
+
+        try await Task.sleep(for: .seconds(5))
+
+        let membership = await adapter.cluster.membershipSnapshot
+        #expect(membership.leader == nil)
+        #expect(membership.isLeader(adapter.cluster.node) == false)
+    }
+
+    @Test("Server promotes a joining adapter to .up, then downs it when it dies")
+    func serverPromotesThenDownsAdapter() async throws {
+        let serverPort = 19_004
+        let adapterPort = 19_005
+
+        let server = await Self.makeServer(port: serverPort)
+        defer { _ = try? server.shutdown() }
+        let adapter = await Self.makeAdapter(port: adapterPort, serverPort: serverPort)
+        let adapterNode = adapter.cluster.node
+
+        adapter.cluster.join(endpoint: server.cluster.endpoint)
+
+        // The server (leader) promotes itself and the adapter to .up.
+        try await server.cluster.waitFor(server.cluster.node, .up, within: .seconds(30))
+        try await server.cluster.waitFor(adapterNode, .up, within: .seconds(30))
+
+        var membership = await server.cluster.membershipSnapshot
+        #expect(membership.leader?.node == server.cluster.node)
+        #expect(membership.isLeader(adapterNode) == false)
+
+        // Kill the adapter; the server (leader, downUnreachableMembersAfter: 10s) evicts it.
+        _ = try? adapter.shutdown()
+
+        try await server.cluster.waitFor(adapterNode, atLeast: .down, within: .seconds(60))
+
+        membership = await server.cluster.membershipSnapshot
+        #expect(membership.member(server.cluster.node)?.status == .up)
+        #expect(membership.leader?.node == server.cluster.node)
+    }
+}

--- a/Tests/SharedDistributedClusterTests/ConnectionStatusDecideTests.swift
+++ b/Tests/SharedDistributedClusterTests/ConnectionStatusDecideTests.swift
@@ -1,0 +1,76 @@
+//
+//  ConnectionStatusDecideTests.swift
+//  HomeAutomationKit
+//
+//  Unit tests for the pure peer-status decision function used to derive `ConnectionStatus`.
+//  Mirrors the verdict matrix from the "Server Down" debugging runbook.
+//
+
+import DistributedCluster
+@testable import SharedDistributedCluster
+import Testing
+
+struct ConnectionStatusDecideTests {
+    typealias Peer = (status: Cluster.MemberStatus, reachability: Cluster.MemberReachability)
+
+    @Test("No peer yet → joining")
+    func noPeer() {
+        #expect(CustomActorSystem.decide(peers: []) == .joining)
+    }
+
+    @Test("Reachable up peer → up")
+    func reachableUp() {
+        let peers: [Peer] = [(status: .up, reachability: .reachable)]
+        #expect(CustomActorSystem.decide(peers: peers) == .up)
+    }
+
+    @Test("Reachable joining peer → joining (mid-handshake)")
+    func reachableJoining() {
+        let peers: [Peer] = [(status: .joining, reachability: .reachable)]
+        #expect(CustomActorSystem.decide(peers: peers) == .joining)
+    }
+
+    @Test("Up but unreachable peer → error")
+    func upUnreachable() {
+        let peers: [Peer] = [(status: .up, reachability: .unreachable)]
+        #expect(CustomActorSystem.decide(peers: peers) == .error)
+    }
+
+    @Test("Down + reachable peer → error")
+    func downReachable() {
+        let peers: [Peer] = [(status: .down, reachability: .reachable)]
+        #expect(CustomActorSystem.decide(peers: peers) == .error)
+    }
+
+    @Test("Down + unreachable peer → error")
+    func downUnreachable() {
+        let peers: [Peer] = [(status: .down, reachability: .unreachable)]
+        #expect(CustomActorSystem.decide(peers: peers) == .error)
+    }
+
+    @Test("Removed peer → error")
+    func removedPeer() {
+        let peers: [Peer] = [(status: .removed, reachability: .reachable)]
+        #expect(CustomActorSystem.decide(peers: peers) == .error)
+    }
+
+    // The literal incident: a stale dead node lingers (.down/.unreachable) while a fresh instance
+    // re-joins on the same endpoint (.joining). We must report .joining (recovering), not .error.
+    @Test("Replacement: stale down peer + new joining peer → joining")
+    func replacementInProgress() {
+        let peers: [Peer] = [
+            (status: .down, reachability: .unreachable),
+            (status: .joining, reachability: .reachable)
+        ]
+        #expect(CustomActorSystem.decide(peers: peers) == .joining)
+    }
+
+    @Test("A healthy peer wins over a lingering stale peer → up")
+    func healthyWinsOverStale() {
+        let peers: [Peer] = [
+            (status: .up, reachability: .reachable),
+            (status: .down, reachability: .unreachable)
+        ]
+        #expect(CustomActorSystem.decide(peers: peers) == .up)
+    }
+}


### PR DESCRIPTION
## Problem

The Vapor **Server** (`server@8888`, Docker) and the **FlowKit Adapter**
(`homeKitAdapter@7777`, macOS host app under launchctl) form a single
`swift-distributed-actors` cluster. When one node restarts while the other holds a
stale `.up` reference, the cluster gets **stuck in `[joining]` forever**: `/health`
returns `503` (or hangs) → Docker marks the container `unhealthy`, no automations
run, and only a **manual ordered restart** (server, then adapter) recovers it.
This is a recurring incident (see the `HomeAutomation-config` debugging runbook).

**#174 did not fix this** — it assumed a serial event-processing bottleneck, which
misdiagnosed the incident (it kept happening afterwards).

## Verified root cause: two-node leader deadlock

Confirmed against the checked-out library (`swift-distributed-actors` @ `0041f6a`):

- Default election is `.lowestReachable(minNumberOfMembers: 2)` — it needs **≥2
  reachable members** to elect a leader (`Leadership.swift`).
- **Only the leader** promotes `.joining → .up` and removes `.down` members
  (`ClusterShell+LeaderActions.swift`); timeout-based downing is also leader-only.
- So after one node restarts, reachable members drop to 1 → no leader can be
  elected → the re-joining node is **never promoted** and dead members are **never
  removed** → stuck `[joining]`, with no automatic recovery.

## Changes

### Leadership & self-healing (`CustomActorSystem`, `configure.swift`)
- **Only the server may be leader.** Server: `autoLeaderElection =
  .lowestReachable(minNumberOfMembers: 1)` → it self-elects with a single reachable
  member, so it promotes a (re)joining adapter to `.up` and downs dead members. The
  cluster **self-heals**.
- **Adapter: `autoLeaderElection = .none`** → it never becomes leader, which avoids
  a mutual-down split-brain (lowest-address election could otherwise pick the adapter).
- `downUnreachableMembersAfter` raised to 10s (downing now actually fires, so be
  tolerant of brief blips).
- **The server never terminates** anymore (removed the `onDown { exit(1) }`); it
  stays alive and heals as the permanent leader.

### Adapter recovery (`CustomActorSystem`, `FlowKitAdapterApp`)
- Adapter gets `onDown: { exit(1) }` → launchctl restarts it with a **fresh node
  UID** for a clean re-handshake. `onDownAction = .none` keeps the cluster system
  alive so the reconnect loop can run first.
- Reconnect loop now reads **real peer status** from the membership snapshot, downs
  a **stale server member** (`down(member:)`, leader-independent) and re-joins.
- `CustomActorSystem.shutdown()` cancels its tasks + the cluster system and is wired
  into the adapter's `.task` — fixes a leaked cluster node/tasks/port on
  `serverAddress` change.

### Honest status & health (`CustomActorSystem`, `routes.swift`)
- `ConnectionStatus` is now **peer/reachability-based**, folded from `cluster.events`
  into a local `Cluster.Membership` (handles `reachabilityChange`), and broadcast
  with **current-value replay** (replaces `.share()`, which starved late subscribers
  — the adapter has two consumers).
- `/health` races a **5s timeout** → fast `503` (peer not up) vs `504` (timeout)
  instead of hanging the Docker healthcheck.

### Revert #174 (`EventProcessingJob`, separate commit)
- Restore **serial** event processing (ordering for history + triggering). #174's
  "natural backpressure" claim did not hold (`group.addTask` is synchronous →
  unbounded, unordered). `trigger()` stays non-blocking because `AutomationService`
  already runs each long-running `execute()` in a background task.
- `AutomationService` is intentionally **unchanged**.

## Tests
- **`ConnectionStatusDecideTests`** — pure `decide()` verdict matrix incl. the
  replacement case (stale `.down` + new `.joining` → `.joining`, not `.error`).
- **`ClusterLeadershipTests`** (in-process clusters) — server self-elects alone;
  adapter never becomes leader; server promotes a joining adapter to `.up` then
  downs it when it dies.

## Validation
- `swift build` ✅ and the new tests pass in isolation ✅.
- ⚠️ The full local `swift test` and the iOS `xcodebuild` could not complete in this
  environment due to **pre-existing local toolchain issues** (SIGSEGV in
  `ControllerTests`/TCA — reproduces without these changes; CoreSimulator out of
  date; SwiftPM `traits` resolution error in xcodebuild). CI is expected to validate
  the full suite and the iOS apps build.
- Manual end-to-end validation against `HomeAutomation-config` (Docker + launchctl):
  reproduce the runbook scenarios and confirm `/health` returns `200` again without
  manual intervention.