### PR TITLE
Address #175 review: self-down recovery + naming cleanups

### DIFF
--- a/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
+++ b/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
@@ -90,7 +90,7 @@ struct FlowKitAdapter: App, Log {
 
         statusObservationTask?.cancel()
         statusObservationTask = Task {
-            for await status in await system.connectionStatus {
+            for await status in await system.makeConnectionStatusStream() {
                 connectionStatus = status
             }
         }

--- a/Sources/SharedDistributedCluster/CustomActorSystem.swift
+++ b/Sources/SharedDistributedCluster/CustomActorSystem.swift
@@ -77,10 +77,10 @@ public actor CustomActorSystem {
         currentConnectionStatus
     }
 
-    /// A fresh stream of connection status changes. The stream is seeded with the *current* value
-    /// (so late subscribers never miss the latest state — unlike a plain broadcast), followed by
-    /// live updates.
-    public var connectionStatus: AsyncStream<ConnectionStatus> {
+    /// Creates a fresh stream of connection status changes, seeded with the *current* value (so late
+    /// subscribers never miss the latest state — unlike a plain broadcast) followed by live updates.
+    /// Each call registers a new subscriber, so call it once per consumer.
+    public func makeConnectionStatusStream() -> AsyncStream<ConnectionStatus> {
         let (stream, continuation) = AsyncStream.makeStream(
             of: ConnectionStatus.self,
             bufferingPolicy: .bufferingNewest(1)
@@ -176,13 +176,26 @@ public actor CustomActorSystem {
         return .error
     }
 
-    /// Derives the connection status for `selfNode` from a full membership, considering only peers
-    /// (members other than self) and their reachability.
-    public static func connectionStatus(for membership: Cluster.Membership, selfNode: Cluster.Node) -> ConnectionStatus {
+    /// Derives the peer connection status for `selfNode` from a full membership, considering only
+    /// peers (members other than self) and their reachability.
+    public static func peerStatus(in membership: Cluster.Membership, selfNode: Cluster.Node) -> ConnectionStatus {
         let peers = membership.members(atLeast: .joining)
             .filter { $0.node != selfNode }
             .map { (status: $0.status, reachability: $0.reachability) }
         return decide(peers: peers)
+    }
+
+    /// Whether the local node has been moved to `.down`/`.removed` (e.g. evicted by the leader after a
+    /// partition). This is terminal for the current node UID — the only recovery is a process restart
+    /// (a fresh UID). `.leaving` is intentionally *not* treated as down (graceful, never self-initiated
+    /// here). A `nil` status (self not yet in the membership) is not down.
+    static func isLocalNodeDown(selfStatus: Cluster.MemberStatus?) -> Bool {
+        guard let selfStatus else { return false }
+        return selfStatus >= .down
+    }
+
+    static func isLocalNodeDown(in membership: Cluster.Membership, selfNode: Cluster.Node) -> Bool {
+        isLocalNodeDown(selfStatus: membership.member(selfNode)?.status)
     }
 
     private func startStatusTask() {
@@ -195,7 +208,13 @@ public actor CustomActorSystem {
             for await event in events {
                 Self.log.debug("Cluster event: \(event)")
                 _ = try? membership.apply(event: event)
-                let status = Self.connectionStatus(for: membership, selfNode: selfNode)
+
+                // Terminal: our own node was evicted by the leader — restart for a clean rejoin.
+                if Self.isLocalNodeDown(in: membership, selfNode: selfNode) {
+                    await self.recoverFromLocalNodeDown()
+                }
+
+                let status = Self.peerStatus(in: membership, selfNode: selfNode)
                 await self.handleStatus(status)
             }
         }
@@ -240,6 +259,15 @@ public actor CustomActorSystem {
         subscribers[id] = nil
     }
 
+    /// Called when the local node was downed/removed by the leader. Terminal for this UID, so we
+    /// hand off to `onDown` immediately (no grace) — the adapter restarts via launchctl with a fresh
+    /// UID. The server passes `onDown == nil` and is unaffected (it is the leader and never downs itself).
+    private func recoverFromLocalNodeDown() {
+        guard let onDown else { return }
+        Self.log.critical("Local node was downed/removed by the cluster leader — restarting for a clean rejoin.")
+        onDown()
+    }
+
     // MARK: - Reconnection (adapter)
 
     private func tryReconnectIfNeededInBackground() {
@@ -253,7 +281,14 @@ public actor CustomActorSystem {
                 do {
                     let snapshot = await self.actorSystem.cluster.membershipSnapshot
                     let selfNode = self.actorSystem.cluster.node
-                    let status = Self.connectionStatus(for: snapshot, selfNode: selfNode)
+
+                    // Poll-based fallback (in case the membership event never arrives): if our own node
+                    // was evicted, restart rather than lingering as a zombie that believes it's connected.
+                    if Self.isLocalNodeDown(in: snapshot, selfNode: selfNode) {
+                        await self.recoverFromLocalNodeDown()
+                    }
+
+                    let status = Self.peerStatus(in: snapshot, selfNode: selfNode)
 
                     if status != .up {
                         // Evict any stale server node lingering on the target endpoint (a previous

--- a/Tests/SharedDistributedClusterTests/LocalNodeDownTests.swift
+++ b/Tests/SharedDistributedClusterTests/LocalNodeDownTests.swift
@@ -1,0 +1,45 @@
+//
+//  LocalNodeDownTests.swift
+//  HomeAutomationKit
+//
+//  Unit tests for local-node-down detection. When the leader evicts the local node (e.g. after a
+//  partition longer than `downUnreachableMembersAfter`), the node is terminal for its current UID and
+//  must restart — peer-based status alone would miss this (it filters out self).
+//
+
+import DistributedCluster
+@testable import SharedDistributedCluster
+import Testing
+
+struct LocalNodeDownTests {
+    @Test(".down is terminal")
+    func down() {
+        #expect(CustomActorSystem.isLocalNodeDown(selfStatus: .down) == true)
+    }
+
+    @Test(".removed is terminal")
+    func removed() {
+        #expect(CustomActorSystem.isLocalNodeDown(selfStatus: .removed) == true)
+    }
+
+    @Test(".up is healthy")
+    func up() {
+        #expect(CustomActorSystem.isLocalNodeDown(selfStatus: .up) == false)
+    }
+
+    @Test(".joining is not down")
+    func joining() {
+        #expect(CustomActorSystem.isLocalNodeDown(selfStatus: .joining) == false)
+    }
+
+    // .leaving is a graceful transition (never self-initiated here) and must not trigger a restart.
+    @Test(".leaving is not treated as down")
+    func leaving() {
+        #expect(CustomActorSystem.isLocalNodeDown(selfStatus: .leaving) == false)
+    }
+
+    @Test("nil (self not yet in membership) is not down")
+    func notInMembership() {
+        #expect(CustomActorSystem.isLocalNodeDown(selfStatus: nil) == false)
+    }
+}


### PR DESCRIPTION
Post-merge code-review follow-up to #175.

## Major: handle the local node being downed by the leader

#175's recovery is **peer-based** (`peerStatus(in:selfNode:)` filters out self). That misses the case where the **server (leader) evicts the adapter** after a partition longer than `downUnreachableMembersAfter` (10s): the adapter's own node is `.down`/tombstoned, but if it still observes the server as `.up`/reachable, the peer status reads `.up` — so neither the grace timer nor the reconnect loop fire, and the adapter lingers as a **zombie that believes it is connected**. Recovery would then rely solely on SWIM marking the server unreachable, which is exactly the signal the original incident shows to be unreliable.

**Fix:** explicitly detect the local node at `.down`/`.removed` and hand off to `onDown` **immediately** (no grace) → the adapter restarts via launchctl with a fresh UID for a clean rejoin. Checked in two places:
- the cluster-event loop (`startStatusTask`) — event-driven, prompt;
- the reconnect loop — poll-based fallback, in case the membership event never arrives.

The server is unaffected (`onDown == nil`; it is the permanent leader and never downs itself). `.leaving` is intentionally not treated as down.

The decision is the pure, unit-tested `isLocalNodeDown(selfStatus:)`.

## Tests
`LocalNodeDownTests`: `.down`/`.removed` → terminal; `.up`/`.joining`/`.leaving`/`nil` → not down.

## Minor: naming cleanups
- `connectionStatus(for:selfNode:)` (static) → **`peerStatus(in:selfNode:)`** — removes the confusing overload with the instance member.
- instance `var connectionStatus` → **`func makeConnectionStatusStream()`** — each access registers a new subscriber (a side effect), so a method name communicates intent; updated the adapter call site.

## Not addressed (intentional)
- `/health` cooperative DB-query cancellation on timeout: impact is negligible for `SELECT 1`; a true cancel isn't worth the risk.
- `ClusterLeadershipTests` fixed ports: low flakiness risk on clean runners; left as-is.
- `AutomationService` `runningTasks` self-cancel smell: pre-existing, out of scope (kept unchanged per the original decision).

## Verification
`swift build` ✅, `swift test` for `LocalNodeDownTests` + `ConnectionStatusDecideTests` (15) and `ClusterLeadershipTests` (3) all green; `swiftlint` clean. CI validates the full suite + iOS apps build (now unblocked by the xctest-dynamic-overlay 1.9.0 bump from #175).