### PR TITLE
Speed up branch Docker build with GHA layer cache

### DIFF
--- a/.github/workflows/docker-branches.yaml
+++ b/.github/workflows/docker-branches.yaml
@@ -34,6 +34,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
@@ -49,6 +52,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@
 # ================================
 FROM swift:6.3-noble AS build
 
-# Install OS updates
+# Install build dependencies (skip blanket dist-upgrade for faster, cache-stable builds)
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \
-    && apt-get -q dist-upgrade -y \
     && apt-get install -y libjemalloc-dev
 
 # Set up a build area


### PR DESCRIPTION
## Problem

The **Create and publish a Docker image (amd64 only)** workflow (`docker-branches.yaml`), which runs on every push to `develop`/`main`, consistently takes **~13–14 min**. It had **no caching** at all, so every push recompiled the entire Swift release build from scratch.

Recent runs:
- `17:35 → 17:48` ≈ 13:45 min
- `20:48 → 21:02` ≈ 13:49 min
- `05:12 → 05:26` ≈ 13:41 min

(The PR-checks Docker job already used `type=gha` cache — the branch build simply lagged behind.)

## Changes

- **`docker-branches.yaml`**
  - Add `Set up Docker Buildx` step (required for the `gha` cache exporter — the default docker driver can't export it).
  - Enable `cache-from: type=gha` / `cache-to: type=gha,mode=max`.
- **`Dockerfile`**
  - Drop the blanket `apt-get dist-upgrade` from the **build stage** so its apt layer stays cache-stable. The build stage isn't shipped, and `libjemalloc-dev` is still pulled in a current version via `apt-get install` after `update`.
  - The **runtime-stage** `dist-upgrade` is intentionally kept, so the shipped image still receives OS security patches.

## Expected effect

The apt layer and the `swift package resolve` layer are now restored from the GHA cache (as long as `Package.*` is unchanged) → roughly **~2–3 min** saved per push.

## Not included (intentional)

The actual `swift build -c release` still runs in full — Docker layer caching can't help there because `COPY . .` invalidates everything below it on any source change. Caching the compile would require a BuildKit `.build` cache mount (+ `buildkit-cache-dance` to persist it across runs), which is a larger, higher-risk change left for a follow-up.