### PR TITLE
Dispatch PR checks after Renovate Package.resolved update

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - develop
+  # Allow the renovate-package-resolved workflow to dispatch these checks after
+  # it commits a regenerated Package.resolved (that commit is pushed with
+  # GITHUB_TOKEN and therefore cannot trigger pull_request runs itself).
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/renovate-package-resolved.yaml
+++ b/.github/workflows/renovate-package-resolved.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: macos-26
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout repository
@@ -44,3 +45,13 @@ jobs:
           git add Package.resolved "Apps/FlowKitAdapter/FlowKit Adapter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved" "Apps/FlowKitController/FlowKit Controller.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
           git commit -m "Package.resolved updated"
           git push
+
+      - name: Trigger PR checks
+        # The commit pushed above uses GITHUB_TOKEN, which GitHub deliberately
+        # prevents from triggering further workflow runs. Without this the PR
+        # checks never run against the regenerated Package.resolved. Dispatch
+        # them explicitly (workflow_dispatch is exempt from that restriction).
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pr-checks.yml --ref "${{ github.ref_name }}"


### PR DESCRIPTION
## Problem

When Renovate opens a dependency PR, the iOS `Package.resolved` files are missing/stale. The `renovate-package-resolved.yaml` workflow regenerates them (`swift package resolve` + `xcodebuild -resolvePackageDependencies`) and commits the result — but it pushes that commit with `secrets.GITHUB_TOKEN`.

GitHub deliberately **does not let `GITHUB_TOKEN`-pushed commits trigger further workflow runs** (anti-recursion). So after the resolve workflow finishes, `pr-checks.yml` never runs against the regenerated `Package.resolved` — the PR head is the bot commit and shows **no checks** (e.g. #178).

## Fix

- **`pr-checks.yml`**: add a `workflow_dispatch` trigger. `workflow_dispatch` (and `repository_dispatch`) are the only events exempt from the `GITHUB_TOKEN` restriction.
- **`renovate-package-resolved.yaml`**: after committing the regenerated `Package.resolved`, explicitly `gh workflow run pr-checks.yml --ref <branch>`, and grant the job `actions: write` so it can dispatch.

The dispatched run executes against the renovate branch head (= the new commit), so its check results attach to the PR head SHA and appear on the PR.

## Notes

- Default branch is `develop`, so `workflow_dispatch` becomes active for dispatch as soon as this merges — no need to reach `main`.
- The dispatch only fires when `Package.resolved` actually changed; the GITHUB_TOKEN push of the resolve workflow does not re-trigger the resolve workflow itself, so there is no loop.
- Existing renovate PRs (e.g. #178) pick this up once rebased onto the updated `develop`.