### PR TITLE
Hold apple/swift-log below 1.13 (breaks swift-cluster-membership)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
     {
       "matchManagers": ["swift"],
       "rangeStrategy": "bump"
+    },
+    {
+      "description": "Hold apple/swift-log below 1.13: its source-breaking MetadataValue string-interpolation change breaks swift-cluster-membership (transitive via swift-distributed-actors). Remove once distributed-actors/cluster-membership builds against swift-log 1.13.",
+      "matchManagers": ["swift"],
+      "matchPackageNames": ["apple/swift-log", "https://github.com/apple/swift-log.git"],
+      "allowedVersions": "<1.13.0"
     }
   ]
 }


### PR DESCRIPTION
## Why

`swift-log` **1.13.0** shipped a *source-breaking* change to `MetadataValue`'s string interpolation. That breaks **swift-cluster-membership** (pulled in transitively via `swift-distributed-actors`), which builds log metadata with `"\(reflecting:)"`:

```
swift-cluster-membership/SWIMInstance.swift:1711: error: extraneous argument label 'reflecting:' in call
  "swim/members/all": Logger.Metadata.Value.array(self.members.map { "\(reflecting: $0)" })
```

Proof: `develop` builds green with swift-log **1.12.0**; Renovate PR #178 fails CI **only** because it bumps swift-log to **1.13.1** — identical `swift-cluster-membership` pin (`020d875`). The other 5 bumps in #178 are fine.

## What

Add a Renovate `packageRule` constraining `apple/swift-log` to `<1.13.0`. With `group:all`, Renovate will regroup #178 with the 5 compatible updates and drop the swift-log bump, so the grouped PR can go green.

## Removal

Delete this rule once `swift-distributed-actors` / `swift-cluster-membership` is updated to build against swift-log 1.13.

## Verify

After merge, confirm on the next Renovate run that #178 (or its successor) no longer includes swift-log 1.13.x. If swift-log still appears, the package matcher needs adjusting to Renovate's internal name for this dep.