### PR TITLE
Fix Swift 6.3 Docker build: bump async-kit to 1.22.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "6f3615ccf2ac3c2ae0c8087d527546e9544a43dd",
-        "version" : "1.21.0"
+        "revision" : "6bbb83cbf9d886623a967a965c8fb1b73e6566f9",
+        "version" : "1.22.0"
       }
     },
     {
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "3eea09220e07d34ace722221cbda90306f48c86c",
-        "version" : "2.90.1"
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
       }
     },
     {


### PR DESCRIPTION
## Problem

The Docker image build fails on `develop` ([failed run](https://github.com/JulianKahnert/HomeAutomation/actions/runs/27846958518/job/82418044965)) with errors like:

```
error: initializer 'init(minimumCapacity:persistent:)' is not available due to missing
import of defining module 'OrderedCollections' [#MemberImportVisibility]
... 'DequeModule' [#MemberImportVisibility]
in async-kit/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
```

## Root cause

The Docker base image was bumped `swift:6.2-noble` → `swift:6.3-noble` (Renovate #148). Swift 6.3 enforces the `MemberImportVisibility` rule, which exposes a latent bug in the transitive dependency **async-kit 1.21.0**: `EventLoopConnectionPool.swift` imports only the umbrella `Collections` module, so members of `OrderedCollections`/`DequeModule` are no longer visible.

The macOS "Swift Package Build & Test" job passes because it runs an older Swift toolchain that doesn't enforce this rule.

## Fix

[async-kit 1.22.0](https://github.com/vapor/async-kit/pull/113) adds the explicit `import OrderedCollections` / `import DequeModule`. Bumping it requires raising `swift-nio` (1.22.0 needs `from: 2.95.0`):

| Package | Before | After |
|---|---|---|
| async-kit | 1.21.0 | 1.22.0 |
| swift-nio | 2.90.1 | 2.101.0 |

- `swift-log` stays locked at `exact: 1.12.1` (the #180 hold).
- Nothing else in the dependency graph moved.
- Only `Package.resolved` changed — no manifest edits needed (all constraints were already open `from:`).

## Verification

`swift build --product Server` on local Swift 6.4 (newer than Docker's 6.3, so it exercises the same `MemberImportVisibility` check): **Build complete**, only pre-existing warnings.