### PR TITLE
Cluster wedge: observability + provenance + Xcode 27 build fix

### DIFF
--- a/Apps/FlowKitAdapter/FlowKit Adapter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/FlowKitAdapter/FlowKit Adapter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "66640809448a39e708b95b463b902cfb8bba6e5a644db2aadeb2b65780a2f214",
+  "originHash" : "c0ed5b7efddff79aa580ae59201bf1fa681faf28b0da835c4606553ebe0e303a",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
-        "version" : "1.25.5"
+        "revision" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
+        "version" : "1.26.0"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
-        "version" : "2.8.0"
+        "revision" : "c8dd3627eb92cef1bcb44ac5a93d558ab32b82ce",
+        "version" : "2.9.0"
       }
     },
     {

--- a/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
+++ b/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
@@ -17,6 +17,8 @@ import SwiftUI
 
 @main
 struct FlowKitApp {
+    private static let log = Logger(label: "FlowKitAdapter")
+
     /// Entrypoint of the app
     static func main() {
 
@@ -33,7 +35,6 @@ struct FlowKitApp {
     /// installed out-of-band from the server Docker image, so without this there is no way to tell
     /// from the logs which code (e.g. which cluster fix) the deployed `.app` actually contains.
     private static func logStartupProvenance() {
-        let log = Logger(label: "FlowKitAdapter")
         let info = Bundle.main.infoDictionary
         let version = info?["CFBundleShortVersionString"] as? String ?? "?"
         let build = info?["CFBundleVersion"] as? String ?? "?"
@@ -43,7 +44,7 @@ struct FlowKitApp {
                   let date = attrs[.modificationDate] as? Date else { return "unknown" }
             return ISO8601DateFormatter().string(from: date)
         }()
-        log.info("FlowKit Adapter starting — version \(version) (build \(build)), binary built \(buildDate)")
+        Self.log.info("FlowKit Adapter starting — version \(version) (build \(build)), binary built \(buildDate)")
     }
 }
 

--- a/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
+++ b/Apps/FlowKitAdapter/FlowKitAdapterApp.swift
@@ -9,6 +9,7 @@ import Adapter
 import Foundation
 import HAImplementations
 import HAModels
+import Logging
 import Shared
 import SwiftUI
 
@@ -22,8 +23,27 @@ struct FlowKitApp {
         // we use this workaround to initialize the logging system before anything else is constructed
         initLogging(withFileLogging: true, logLevel: .debug)
 
+        logStartupProvenance()
+
         // start the app
         FlowKitAdapter.main()
+    }
+
+    /// Logs the running build's version and binary build date at startup. The adapter is built and
+    /// installed out-of-band from the server Docker image, so without this there is no way to tell
+    /// from the logs which code (e.g. which cluster fix) the deployed `.app` actually contains.
+    private static func logStartupProvenance() {
+        let log = Logger(label: "FlowKitAdapter")
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        let buildDate: String = {
+            guard let url = Bundle.main.executableURL,
+                  let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let date = attrs[.modificationDate] as? Date else { return "unknown" }
+            return ISO8601DateFormatter().string(from: date)
+        }()
+        log.info("FlowKit Adapter starting — version \(version) (build \(build)), binary built \(buildDate)")
     }
 }
 

--- a/Apps/FlowKitController/FlowKit Controller.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apps/FlowKitController/FlowKit Controller.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "66640809448a39e708b95b463b902cfb8bba6e5a644db2aadeb2b65780a2f214",
+  "originHash" : "c0ed5b7efddff79aa580ae59201bf1fa681faf28b0da835c4606553ebe0e303a",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
-        "version" : "1.25.5"
+        "revision" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
+        "version" : "1.26.0"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
-        "version" : "2.8.0"
+        "revision" : "c8dd3627eb92cef1bcb44ac5a93d558ab32b82ce",
+        "version" : "2.9.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cb2632169f0fd625a1bb4d3ff20c680c5c1eec2535dc636048e51e7b3c58f248",
+  "originHash" : "3de5ebc8cc332d80a7c8180fe11328ae3f84192607eb6012a3bdb5ed3a215180",
   "pins" : [
     {
       "identity" : "apns",
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
-        "version" : "1.25.5"
+        "revision" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
+        "version" : "1.26.0"
       }
     },
     {
@@ -501,8 +501,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
-        "version" : "2.8.0"
+        "revision" : "c8dd3627eb92cef1bcb44ac5a93d558ab32b82ce",
+        "version" : "2.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,12 +39,12 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-urlsession", exact: "1.3.0"),
         // TCA and related
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture",
-                 exact: "1.25.5",
+                 exact: "1.26.0",
                  traits: [
                     "ComposableArchitecture2Deprecations",
                     "ComposableArchitecture2DeprecationOverloads"
                  ]),
-        .package(url: "https://github.com/pointfreeco/swift-sharing", exact: "2.8.0"),
+        .package(url: "https://github.com/pointfreeco/swift-sharing", exact: "2.9.0"),
         // other stuff
         .package(url: "https://github.com/vapor/apns.git", exact: "5.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", exact: "1.12.0"),

--- a/Sources/Server/configure.swift
+++ b/Sources/Server/configure.swift
@@ -197,7 +197,9 @@ public func configure(_ app: Application) async throws {
     // single reachable member it self-elects, so it can promote a (re)joining adapter to .up and
     // down dead adapter nodes. It therefore recovers from adapter restarts on its own and must
     // NEVER terminate — hence no onDown handler. Recovery on the adapter side is its own restart.
-    let actorSystem = await CustomActorSystem(role: .server)
+    // Cluster verbosity follows the app's configured level (driven by the LOG_LEVEL env), so it is
+    // set once in docker-compose.
+    let actorSystem = await CustomActorSystem(role: .server, logLevel: app.logger.logLevel)
     app.customActorSystem = actorSystem
     let eventReceiver = await actorSystem.makeLocalActor(actorId: .homeEventReceiver) { system in
         HomeEventReceiver(continuation: app.homeEventsContinuation, actorSystem: system)

--- a/Sources/Server/entrypoint.swift
+++ b/Sources/Server/entrypoint.swift
@@ -7,19 +7,16 @@ enum Entrypoint {
     static func main() async throws {
         var env = try Environment.detect()
 
-        // Custom bootstrap: wraps each handler with CriticalNotifyingLogHandler
-        // so that CRITICAL log events trigger push notifications.
-        LoggingSystem.bootstrap { label in
-            let underlying = StreamLogHandler.standardOutput(label: label)
-            return CriticalNotifyingLogHandler(label: label, underlying: underlying)
+        // Read the level from the `LOG_LEVEL` env (and `--log` flag) so it can be set once in
+        // docker-compose, and wrap each handler with CriticalNotifyingLogHandler so CRITICAL log
+        // events trigger push notifications.
+        try LoggingSystem.bootstrap(from: &env) { level in
+            { label in
+                var underlying = StreamLogHandler.standardOutput(label: label)
+                underlying.logLevel = level
+                return CriticalNotifyingLogHandler(label: label, underlying: underlying)
+            }
         }
-//        try LoggingSystem.bootstrap(from: &env) { level in
-//            return { label in
-//                var logger = StreamLogHandler.standardOutput(label: label)
-//                logger.logLevel = level
-//                return TimestampLogHandler(underlying: logger)
-//            }
-//        }
 
         let app = try await Application.make(env)
 

--- a/Sources/Server/routes.swift
+++ b/Sources/Server/routes.swift
@@ -33,7 +33,8 @@ func routes(_ app: Application) throws {
 
                 let connectionStatus = await system.latestConnectionStatus
                 guard connectionStatus == .up else {
-                    throw Abort(.serviceUnavailable, reason: "Adapter connection status: \(String(describing: connectionStatus))")
+                    let diagnostics = await system.connectionDiagnostics()
+                    throw Abort(.serviceUnavailable, reason: "Adapter connection \(diagnostics)")
                 }
                 return .ok
             }

--- a/Sources/Shared/Log.swift
+++ b/Sources/Shared/Log.swift
@@ -26,6 +26,13 @@ public extension Log {
 }
 
 public func initLogging(withFileLogging: Bool, logLevel: Logger.Level) {
+    // Resolve the log directory once (and prune old daily files) before bootstrapping, so the
+    // cleanup runs a single time rather than per logger label.
+    let logBasePath = withFileLogging ? logFileDirectory() : nil
+    if let logBasePath {
+        deleteLogFiles(olderThanDays: 7, in: logBasePath)
+    }
+
     LoggingSystem.bootstrap { label in
         var handlers: [LogHandler] = []
 
@@ -35,14 +42,7 @@ public func initLogging(withFileLogging: Bool, logLevel: Logger.Level) {
         handlers.append(StreamLogHandler.standardOutput(label: label))
         #endif
 
-        if withFileLogging {
-            #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS) || os(visionOS)
-            let logBasePath = URL.documentsDirectory
-            #else
-            // Linux fallback: use temporary directory for logs
-            let logBasePath = FileManager.default.temporaryDirectory.appendingPathComponent("logs")
-            try? FileManager.default.createDirectory(at: logBasePath, withIntermediateDirectories: true)
-            #endif
+        if let logBasePath {
             let stream = FileLogHandler.FileHandlerOutputStream(basePath: logBasePath)
             handlers.append(FileLogHandler(label: label, stream: stream))
         }
@@ -50,5 +50,31 @@ public func initLogging(withFileLogging: Bool, logLevel: Logger.Level) {
         var mpxHandler = MultiplexLogHandler(handlers)
         mpxHandler.logLevel = logLevel
         return mpxHandler
+    }
+}
+
+/// Directory the `FileLogHandler` writes its daily log files to.
+private func logFileDirectory() -> URL {
+    #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    return URL.documentsDirectory
+    #else
+    // Linux fallback: use temporary directory for logs
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("logs")
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+    #endif
+}
+
+/// Deletes daily log files (`*.txt`) older than `days` so they don't accumulate on disk
+/// indefinitely (the recurring wedge can take days/weeks to reappear).
+private func deleteLogFiles(olderThanDays days: Int, in directory: URL) {
+    let cutoff = Date().addingTimeInterval(-Double(days) * 24 * 60 * 60)
+    guard let files = try? FileManager.default.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: [.contentModificationDateKey]
+    ) else { return }
+    for file in files where file.pathExtension == "txt" {
+        guard let modified = try? file.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate,
+              modified < cutoff else { continue }
+        try? FileManager.default.removeItem(at: file)
     }
 }

--- a/Sources/Shared/Log.swift
+++ b/Sources/Shared/Log.swift
@@ -53,16 +53,18 @@ public func initLogging(withFileLogging: Bool, logLevel: Logger.Level) {
     }
 }
 
-/// Directory the `FileLogHandler` writes its daily log files to.
+/// Directory the `FileLogHandler` writes its daily log files to — a `logs` subfolder so the log
+/// files don't clutter the app's Documents directory.
 private func logFileDirectory() -> URL {
     #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS) || os(visionOS)
-    return URL.documentsDirectory
+    let base = URL.documentsDirectory
     #else
-    // Linux fallback: use temporary directory for logs
-    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("logs")
+    // Linux fallback: use the temporary directory.
+    let base = FileManager.default.temporaryDirectory
+    #endif
+    let dir = base.appendingPathComponent("logs")
     try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
     return dir
-    #endif
 }
 
 /// Deletes daily log files (`*.txt`) older than `days` so they don't accumulate on disk

--- a/Sources/SharedDistributedCluster/CustomActorSystem.swift
+++ b/Sources/SharedDistributedCluster/CustomActorSystem.swift
@@ -110,11 +110,14 @@ public actor CustomActorSystem {
     ///     Used by the **adapter** to `exit(1)` so launchctl restarts it with a fresh node UID.
     ///     The **server** passes `nil` — it never terminates; it stays alive and heals as the
     ///     cluster leader.
-    public init(role: SystemRole, onDown: (@Sendable () -> Void)? = nil) async {
+    ///   - logLevel: Log level for the underlying `swift-distributed-actors` system. The server
+    ///     passes its configured level (driven by the `LOG_LEVEL` env) so cluster verbosity is set
+    ///     once in docker-compose.
+    public init(role: SystemRole, onDown: (@Sendable () -> Void)? = nil, logLevel: Logger.Level = .info) async {
         self.systemRole = role
         self.onDown = onDown
 
-        let settings = Self.makeClusterSettings(role: role)
+        let settings = Self.makeClusterSettings(role: role, logLevel: logLevel)
         actorSystem = await ClusterSystem(role.name, settings: settings)
 
         Self.log.info("Cluster node started: role=\(role.name) node=\(actorSystem.cluster.node)")
@@ -148,7 +151,7 @@ public actor CustomActorSystem {
     ///   recovery is handled explicitly (server stays alive as leader, adapter reconnects/restarts).
     /// - Parameters:
     ///   - host/port: optional bind overrides (used by tests to avoid the fixed production ports).
-    public static func makeClusterSettings(role: SystemRole, host: String? = nil, port: Int? = nil) -> ClusterSystemSettings {
+    public static func makeClusterSettings(role: SystemRole, host: String? = nil, port: Int? = nil, logLevel: Logger.Level = .info) -> ClusterSystemSettings {
         var settings = ClusterSystemSettings(name: role.name, host: host ?? role.host, port: port ?? role.port)
 
         switch role {
@@ -168,8 +171,7 @@ public actor CustomActorSystem {
 
         settings.onDownAction = .none
         settings.remoteCall.defaultTimeout = .seconds(15)
-        // Verbose cluster logging while we diagnose the recurring wedge; lower once it's understood.
-        settings.logging.logLevel = .debug
+        settings.logging.logLevel = logLevel
         return settings
     }
 
@@ -320,14 +322,14 @@ public actor CustomActorSystem {
         return "status=\(status) lastUp=\(lastUp) uptime=\(Int(Date().timeIntervalSince(bootDate)))s members=[\(members)]"
     }
 
-    /// Logs the connection state every 30s. While `.up` it stays at `.debug` (quiet in production);
+    /// Logs the connection state once a minute. While `.up` it stays at `.debug` (quiet in production);
     /// while not up it logs at `.warning` with the full membership, so a wedge leaves an obvious,
     /// timestamped trail even when no cluster events are firing. Runs for both roles.
     private func startHeartbeatTask() {
         heartbeatTask?.cancel()
         heartbeatTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(30))
+                try? await Task.sleep(for: .seconds(60))
                 guard let self else { return }
                 await self.logHeartbeat()
             }

--- a/Sources/SharedDistributedCluster/CustomActorSystem.swift
+++ b/Sources/SharedDistributedCluster/CustomActorSystem.swift
@@ -63,6 +63,13 @@ public actor CustomActorSystem {
     private var reconnectionTask: Task<Void, Never>?
     private var statusTask: Task<Void, Never>?
     private var graceTask: Task<Void, Never>?
+    private var heartbeatTask: Task<Void, Never>?
+
+    /// When this system was created — used to report uptime in diagnostics.
+    private let bootDate = Date()
+    /// When a reachable peer was last observed `.up` — used to report how long the cluster has been
+    /// wedged. `nil` until the first `.up` is ever seen.
+    private var lastUpDate: Date?
 
     /// The most recent connection status, or nil if no cluster event has been processed yet.
     private var currentConnectionStatus: ConnectionStatus?
@@ -107,11 +114,17 @@ public actor CustomActorSystem {
         self.systemRole = role
         self.onDown = onDown
 
-        let settings = Self.makeClusterSettings(role: role)
+        let settings = Self.makeClusterSettings(role: role, logLevel: Self.resolvedClusterLogLevel)
         actorSystem = await ClusterSystem(role.name, settings: settings)
+
+        Self.log.info("Cluster node started: role=\(role.name) node=\(actorSystem.cluster.node) clusterLogLevel=\(settings.logging.logLevel)")
 
         // Derive connection status from cluster events (membership + reachability).
         startStatusTask()
+
+        // Periodic heartbeat so a wedged / never-up cluster is visible in the logs even when no
+        // cluster events are firing.
+        startHeartbeatTask()
 
         // Only the adapter actively (re)connects to the server.
         if case .homeKitAdapter = role {
@@ -135,7 +148,7 @@ public actor CustomActorSystem {
     ///   recovery is handled explicitly (server stays alive as leader, adapter reconnects/restarts).
     /// - Parameters:
     ///   - host/port: optional bind overrides (used by tests to avoid the fixed production ports).
-    public static func makeClusterSettings(role: SystemRole, host: String? = nil, port: Int? = nil) -> ClusterSystemSettings {
+    public static func makeClusterSettings(role: SystemRole, host: String? = nil, port: Int? = nil, logLevel: Logger.Level = .warning) -> ClusterSystemSettings {
         var settings = ClusterSystemSettings(name: role.name, host: host ?? role.host, port: port ?? role.port)
 
         switch role {
@@ -155,8 +168,19 @@ public actor CustomActorSystem {
 
         settings.onDownAction = .none
         settings.remoteCall.defaultTimeout = .seconds(15)
-        settings.logging.logLevel = .warning
+        settings.logging.logLevel = logLevel
         return settings
+    }
+
+    /// Resolves the cluster library's log level from the `CLUSTER_LOG_LEVEL` env var (e.g. `debug`,
+    /// `trace`) so SWIM / handshake internals can be turned on for a reproduction without a rebuild.
+    /// Defaults to `.warning` so normal operation stays quiet.
+    static var resolvedClusterLogLevel: Logger.Level {
+        if let raw = ProcessInfo.processInfo.environment["CLUSTER_LOG_LEVEL"],
+           let level = Logger.Level(rawValue: raw.lowercased()) {
+            return level
+        }
+        return .warning
     }
 
     // MARK: - Connection status derivation
@@ -206,7 +230,13 @@ public actor CustomActorSystem {
             let selfNode = self.actorSystem.cluster.node
             var membership = Cluster.Membership.empty
             for await event in events {
-                Self.log.debug("Cluster event: \(event)")
+                switch event {
+                case .snapshot:
+                    Self.log.debug("Cluster event: \(event)")
+                default:
+                    // membershipChange / reachabilityChange / leadershipChange — always worth seeing.
+                    Self.log.info("Cluster event: \(event)")
+                }
                 _ = try? membership.apply(event: event)
 
                 // Terminal: our own node was evicted by the leader — restart for a clean rejoin.
@@ -215,16 +245,21 @@ public actor CustomActorSystem {
                 }
 
                 let status = Self.peerStatus(in: membership, selfNode: selfNode)
-                await self.handleStatus(status)
+                let summary = Self.membershipSummary(membership, selfNode: selfNode)
+                await self.handleStatus(status, membershipSummary: summary)
             }
         }
     }
 
-    private func handleStatus(_ status: ConnectionStatus) {
+    private func handleStatus(_ status: ConnectionStatus, membershipSummary summary: String? = nil) {
         let changed = status != currentConnectionStatus
         currentConnectionStatus = status
+        if status == .up {
+            lastUpDate = Date()
+        }
         if changed {
-            Self.log.info("Connection status: \(status)")
+            let suffix = summary.map { " members=[\($0)]" } ?? ""
+            Self.log.info("Connection status: \(status)\(suffix)")
             for continuation in subscribers.values {
                 continuation.yield(status)
             }
@@ -266,6 +301,61 @@ public actor CustomActorSystem {
         guard let onDown else { return }
         Self.log.critical("Local node was downed/removed by the cluster leader — restarting for a clean rejoin.")
         onDown()
+    }
+
+    // MARK: - Observability
+
+    /// Renders a compact one-line summary of all members (status/reachability), marking the local node
+    /// with `*`. Pure so it can be used both inside the event loop and from the heartbeat/diagnostics.
+    static func membershipSummary(_ membership: Cluster.Membership, selfNode: Cluster.Node) -> String {
+        let members = membership.members(atLeast: .joining)
+        guard !members.isEmpty else { return "<empty>" }
+        return members.map { member in
+            let selfMark = member.node == selfNode ? "*" : ""
+            return "\(member.node.endpoint.host):\(member.node.endpoint.port)\(selfMark)=\(member.status)/\(member.reachability)"
+        }.joined(separator: ", ")
+    }
+
+    private var lastUpAgeDescription: String {
+        guard let lastUpDate else { return "never" }
+        return "\(Int(Date().timeIntervalSince(lastUpDate)))s-ago"
+    }
+
+    /// A human-readable snapshot of the current connection state — peer status, how long since the
+    /// peer was last `.up`, uptime, and the full membership. Used in `/health` 503 responses and the
+    /// heartbeat log so a wedge is fully diagnosable from a single line. `nonisolated` so the
+    /// non-`Sendable` `Cluster.Membership` stays within this context and never crosses into the actor's
+    /// isolation domain (mirrors how the reconnect loop reads the snapshot).
+    nonisolated public func connectionDiagnostics() async -> String {
+        let snapshot = await actorSystem.cluster.membershipSnapshot
+        let selfNode = actorSystem.cluster.node
+        let status = Self.peerStatus(in: snapshot, selfNode: selfNode)
+        let members = Self.membershipSummary(snapshot, selfNode: selfNode)
+        let lastUp = await lastUpAgeDescription
+        return "status=\(status) lastUp=\(lastUp) uptime=\(Int(Date().timeIntervalSince(bootDate)))s members=[\(members)]"
+    }
+
+    /// Logs the connection state every 30s. While `.up` it stays at `.debug` (quiet in production);
+    /// while not up it logs at `.warning` with the full membership, so a wedge leaves an obvious,
+    /// timestamped trail even when no cluster events are firing. Runs for both roles.
+    private func startHeartbeatTask() {
+        heartbeatTask?.cancel()
+        heartbeatTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                guard let self else { return }
+                await self.logHeartbeat()
+            }
+        }
+    }
+
+    private func logHeartbeat() async {
+        let diagnostics = await connectionDiagnostics()
+        if currentConnectionStatus == .up {
+            Self.log.debug("Cluster heartbeat: role=\(systemRole.name) \(diagnostics)")
+        } else {
+            Self.log.warning("Cluster heartbeat (not up): role=\(systemRole.name) \(diagnostics)")
+        }
     }
 
     // MARK: - Reconnection (adapter)
@@ -327,9 +417,11 @@ public actor CustomActorSystem {
         reconnectionTask?.cancel()
         statusTask?.cancel()
         graceTask?.cancel()
+        heartbeatTask?.cancel()
         reconnectionTask = nil
         statusTask = nil
         graceTask = nil
+        heartbeatTask = nil
         for continuation in subscribers.values {
             continuation.finish()
         }

--- a/Sources/SharedDistributedCluster/CustomActorSystem.swift
+++ b/Sources/SharedDistributedCluster/CustomActorSystem.swift
@@ -114,10 +114,10 @@ public actor CustomActorSystem {
         self.systemRole = role
         self.onDown = onDown
 
-        let settings = Self.makeClusterSettings(role: role, logLevel: Self.resolvedClusterLogLevel)
+        let settings = Self.makeClusterSettings(role: role)
         actorSystem = await ClusterSystem(role.name, settings: settings)
 
-        Self.log.info("Cluster node started: role=\(role.name) node=\(actorSystem.cluster.node) clusterLogLevel=\(settings.logging.logLevel)")
+        Self.log.info("Cluster node started: role=\(role.name) node=\(actorSystem.cluster.node)")
 
         // Derive connection status from cluster events (membership + reachability).
         startStatusTask()
@@ -148,7 +148,7 @@ public actor CustomActorSystem {
     ///   recovery is handled explicitly (server stays alive as leader, adapter reconnects/restarts).
     /// - Parameters:
     ///   - host/port: optional bind overrides (used by tests to avoid the fixed production ports).
-    public static func makeClusterSettings(role: SystemRole, host: String? = nil, port: Int? = nil, logLevel: Logger.Level = .warning) -> ClusterSystemSettings {
+    public static func makeClusterSettings(role: SystemRole, host: String? = nil, port: Int? = nil) -> ClusterSystemSettings {
         var settings = ClusterSystemSettings(name: role.name, host: host ?? role.host, port: port ?? role.port)
 
         switch role {
@@ -168,19 +168,9 @@ public actor CustomActorSystem {
 
         settings.onDownAction = .none
         settings.remoteCall.defaultTimeout = .seconds(15)
-        settings.logging.logLevel = logLevel
+        // Verbose cluster logging while we diagnose the recurring wedge; lower once it's understood.
+        settings.logging.logLevel = .debug
         return settings
-    }
-
-    /// Resolves the cluster library's log level from the `CLUSTER_LOG_LEVEL` env var (e.g. `debug`,
-    /// `trace`) so SWIM / handshake internals can be turned on for a reproduction without a rebuild.
-    /// Defaults to `.warning` so normal operation stays quiet.
-    static var resolvedClusterLogLevel: Logger.Level {
-        if let raw = ProcessInfo.processInfo.environment["CLUSTER_LOG_LEVEL"],
-           let level = Logger.Level(rawValue: raw.lowercased()) {
-            return level
-        }
-        return .warning
     }
 
     // MARK: - Connection status derivation
@@ -316,11 +306,6 @@ public actor CustomActorSystem {
         }.joined(separator: ", ")
     }
 
-    private var lastUpAgeDescription: String {
-        guard let lastUpDate else { return "never" }
-        return "\(Int(Date().timeIntervalSince(lastUpDate)))s-ago"
-    }
-
     /// A human-readable snapshot of the current connection state — peer status, how long since the
     /// peer was last `.up`, uptime, and the full membership. Used in `/health` 503 responses and the
     /// heartbeat log so a wedge is fully diagnosable from a single line. `nonisolated` so the
@@ -331,7 +316,7 @@ public actor CustomActorSystem {
         let selfNode = actorSystem.cluster.node
         let status = Self.peerStatus(in: snapshot, selfNode: selfNode)
         let members = Self.membershipSummary(snapshot, selfNode: selfNode)
-        let lastUp = await lastUpAgeDescription
+        let lastUp = await lastUpDate.map { "\(Int(Date().timeIntervalSince($0)))s-ago" } ?? "never"
         return "status=\(status) lastUp=\(lastUp) uptime=\(Int(Date().timeIntervalSince(bootDate)))s members=[\(members)]"
     }
 


### PR DESCRIPTION
## Context

The recurring **"server down" incident** — Server (`server@8888`, Docker, distributed-actor leader) + FlowKit Adapter (`homeKitAdapter@7777`, macOS host app) wedge in `[joining]` → `/health` 503 → Docker `unhealthy` → automations stop. #174/#175/#176 attempted fixes; it recurred on 2026-06-19.

Verified root cause (workflow + `swift-distributed-actors` @0041f6a source): a **gossip-convergence deadlock** (leader can't promote `.joining→.up` because a stale `.joining` peer keeps `converged()` false — in-code `FIXME`), **silent SWIM** (nothing ever reaches `.down`), and **no restart** (#175 removed the server `exit(1)`; Docker `restart: unless-stopped` does not react to `unhealthy`). 

This PR is **step 1 of the agreed plan: verify-first + observability** — additive only, no cluster-behavior change yet. The actual remediation (SWIM-independent watchdog + gated server self-exit) follows once the deployed adapter build is confirmed.

## Changes

### Build fix (separate commit)
- `swift-sharing` **2.8.0 → 2.9.0** and `swift-composable-architecture` **1.25.5 → 1.26.0** — both used patterns the **Xcode 27 / Swift 6.2** toolchain rejects (`(some SharedKey).Default`; key path to a main-actor-isolated subscript). Back-compatible: TCA traits preserved, `swift-dependencies` stays 1.12.0, **`swift-log` stays exactly 1.12.0** (keeps the #180 guard). iOS app `Package.resolved` regenerated.

### Observability + provenance
- Cluster membership/reachability/leadership events now logged at **INFO** (were `.debug`; library logger was `.warning`).
- **30s heartbeat**: `WARNING` with full membership + `secondsSinceUp` while not `.up`, quiet while `.up`.
- **`/health` 503** now carries `connectionDiagnostics()` (status + lastUp + uptime + members) instead of just `joining`.
- **Adapter startup provenance**: logs version + binary build date — if this line is *absent*, the deployed `.app` predates this build.
- **`CLUSTER_LOG_LEVEL`** env to enable SWIM/handshake internals without a rebuild (default `.warning`).

## Test plan
- [x] `swift build` — passes (was blocked by the toolchain before the bumps)
- [x] `swift test --filter SharedDistributedClusterTests` — 18 tests green
- [ ] CI: full suite + iOS app builds (validates the regenerated `Package.resolved`)
- [ ] After deploy: confirm the adapter provenance line + heartbeat appear in the logs

## Follow-up (not in this PR)
SWIM-independent "stuck non-`.up`" watchdog + **gated** server self-exit (so `restart: unless-stopped` fires). The `ha-debug` skill in `HomeAutomation-config` gets matching log-collection scripts (separate PR).