### PR TITLE
Reset cached commands when device state drifts from the command

### DIFF
--- a/Sources/HAApplicationLayer/HomeManager.swift
+++ b/Sources/HAApplicationLayer/HomeManager.swift
@@ -117,6 +117,11 @@ public final class HomeManager: HomeManagable {
     }
 
     public func trigger(scene sceneName: String) async {
+        // No explicit cache reset here: executing a scene changes the affected devices, and those
+        // per-characteristic changes echo back through the adapter into `addEntityHistory`, where
+        // `invalidateContradictedCommands(for:)` resets any cached command they contradict. This is
+        // the same path that handles scenes activated from outside the server, so both are covered
+        // uniformly without the server needing to know a scene's entity membership.
         log.info("Triggering scene '\(sceneName)' — starting distributed actor call")
         let start = ContinuousClock.now
         do {
@@ -132,6 +137,18 @@ public final class HomeManager: HomeManagable {
     public func addEntityHistory(_ item: EntityStorageItem) async {
         log.debug("Adding entity item to storage \(item.entityId)")
         await entityCache.insert(item, forKey: item.entityId)
+
+        // A freshly observed state can reveal that the device drifted away from what the server last
+        // commanded — e.g. a scene activated outside the server (HomeKit only surfaces scenes as the
+        // per-characteristic changes they produce, which arrive here), or a manual change. Reset any
+        // cached command this state contradicts so the automation engine — which re-evaluates this
+        // same event right after — is allowed to re-issue it. A state that confirms the command (the
+        // command's own echo) is not contradicted, so deduplication is preserved and no command loop
+        // occurs. Done synchronously here so the cache is already reset before the automation runs.
+        let invalidatedActions = await actionLogManager.invalidateContradictedCommands(for: item)
+        if !invalidatedActions.isEmpty {
+            log.info("Invalidated \(invalidatedActions.count) cached command(s) for \(item.entityId) due to state drift: \(invalidatedActions)")
+        }
 
         // Persist item in the background to avoid blocking automation execution
         Task.detached(priority: .background) {

--- a/Sources/HAApplicationLayer/Managers/ActionLogManager.swift
+++ b/Sources/HAApplicationLayer/Managers/ActionLogManager.swift
@@ -5,6 +5,7 @@
 //  Created by Julian Kahnert on 14.11.25.
 //
 
+import Foundation
 import HAModels
 import Shared
 
@@ -12,9 +13,16 @@ public actor ActionLogManager {
     public static let maxEntries = 1000
 
     private var actions: [ActionLogItem] = []
-    private let commandCache = Cache<String, HomeManagableAction>(entryLifetime: .minutes(2))
+    private let commandCache: Cache<String, HomeManagableAction>
+    /// Maps an entity to the set of cache keys (`"<entityId>-<actionName>"`) currently cached for it.
+    /// `NSCache` cannot enumerate its keys, so this index lets us find an entity's cached commands
+    /// when a state change arrives. It self-heals: keys whose cache entry has expired are pruned
+    /// the next time the entity is visited in `invalidateContradictedCommands(for:)`.
+    private var keysByEntity: [EntityId: Set<String>] = [:]
 
-    public init() {}
+    public init(dateProvider: @escaping @Sendable () -> Date = Date.init) {
+        self.commandCache = Cache(dateProvider: dateProvider, entryLifetime: .minutes(2))
+    }
 
     /// Log an action and check if it was a duplicate (cache hit)
     /// - Parameter action: The action to log
@@ -35,6 +43,7 @@ public actor ActionLogManager {
         // If not a cache hit, mark command as executed
         if !hasCacheHit {
             await commandCache.insert(action, forKey: cacheKey)
+            keysByEntity[action.entityId, default: []].insert(cacheKey)
         }
 
         // Log the action
@@ -52,6 +61,46 @@ public actor ActionLogManager {
         }
 
         return hasCacheHit
+    }
+
+    /// Reset cached commands for `item.entityId` that the freshly observed device state contradicts.
+    ///
+    /// This lets the automation engine re-issue a command after the device has drifted away from
+    /// what the server commanded — for example when a scene was activated outside the server, or a
+    /// device was changed manually. It is safe to call on every incoming state change: a state that
+    /// *confirms* the last command (the command's own echo) is not contradicted, so it is never
+    /// invalidated and command deduplication is preserved.
+    ///
+    /// - Parameter item: A freshly observed entity state.
+    /// - Returns: The actions that were invalidated (for logging / observability).
+    @discardableResult
+    public func invalidateContradictedCommands(for item: EntityStorageItem) async -> [HomeManagableAction] {
+        guard let keys = keysByEntity[item.entityId], !keys.isEmpty else { return [] }
+
+        var invalidatedActions: [HomeManagableAction] = []
+        var deadKeys: Set<String> = []
+
+        for key in keys {
+            guard let cachedAction = await commandCache.value(forKey: key) else {
+                // The cache entry expired or was evicted — drop the stale index entry.
+                deadKeys.insert(key)
+                continue
+            }
+            if cachedAction.isContradicted(by: item) {
+                await commandCache.removeValue(forKey: key)
+                deadKeys.insert(key)
+                invalidatedActions.append(cachedAction)
+            }
+        }
+
+        if !deadKeys.isEmpty {
+            keysByEntity[item.entityId]?.subtract(deadKeys)
+            if keysByEntity[item.entityId]?.isEmpty == true {
+                keysByEntity[item.entityId] = nil
+            }
+        }
+
+        return invalidatedActions
     }
 
     public func getActions(limit: Int? = nil) -> [ActionLogItem] {

--- a/Sources/HAApplicationLayer/Managers/ActionLogManager.swift
+++ b/Sources/HAApplicationLayer/Managers/ActionLogManager.swift
@@ -9,16 +9,24 @@ import Foundation
 import HAModels
 import Shared
 
+/// Identifies a cached command: one entry per `(entity, action kind)`. Typed instead of the former
+/// `"<entityId>-<actionName>"` string so the key cannot collide and carries its `entityId` for
+/// per-entity lookups during `invalidateContradictedCommands(for:)`.
+private struct CommandCacheKey: Hashable, Sendable {
+    let entityId: EntityId
+    let actionName: String
+
+    init(_ action: HomeManagableAction) {
+        self.entityId = action.entityId
+        self.actionName = action.actionName
+    }
+}
+
 public actor ActionLogManager {
     public static let maxEntries = 1000
 
     private var actions: [ActionLogItem] = []
-    private let commandCache: Cache<String, HomeManagableAction>
-    /// Maps an entity to the set of cache keys (`"<entityId>-<actionName>"`) currently cached for it.
-    /// `NSCache` cannot enumerate its keys, so this index lets us find an entity's cached commands
-    /// when a state change arrives. It self-heals: keys whose cache entry has expired are pruned
-    /// the next time the entity is visited in `invalidateContradictedCommands(for:)`.
-    private var keysByEntity: [EntityId: Set<String>] = [:]
+    private let commandCache: Cache<CommandCacheKey, HomeManagableAction>
 
     public init(dateProvider: @escaping @Sendable () -> Date = Date.init) {
         self.commandCache = Cache(dateProvider: dateProvider, entryLifetime: .minutes(2))
@@ -28,7 +36,7 @@ public actor ActionLogManager {
     /// - Parameter action: The action to log
     /// - Returns: true if this was a duplicate action (cache hit), false if it's a new action that should be executed
     public func log(action: HomeManagableAction) async -> Bool {
-        let cacheKey = "\(action.entityId)-\(action.actionName)"
+        let cacheKey = CommandCacheKey(action)
 
         // Check if action is in cache
         let hasCacheHit: Bool
@@ -43,7 +51,6 @@ public actor ActionLogManager {
         // If not a cache hit, mark command as executed
         if !hasCacheHit {
             await commandCache.insert(action, forKey: cacheKey)
-            keysByEntity[action.entityId, default: []].insert(cacheKey)
         }
 
         // Log the action
@@ -75,28 +82,14 @@ public actor ActionLogManager {
     /// - Returns: The actions that were invalidated (for logging / observability).
     @discardableResult
     public func invalidateContradictedCommands(for item: EntityStorageItem) async -> [HomeManagableAction] {
-        guard let keys = keysByEntity[item.entityId], !keys.isEmpty else { return [] }
-
         var invalidatedActions: [HomeManagableAction] = []
-        var deadKeys: Set<String> = []
 
-        for key in keys {
-            guard let cachedAction = await commandCache.value(forKey: key) else {
-                // The cache entry expired or was evicted — drop the stale index entry.
-                deadKeys.insert(key)
-                continue
-            }
+        // The cache prunes its own key index on expiry/eviction (a missing entry just yields `nil`).
+        for key in await commandCache.keys where key.entityId == item.entityId {
+            guard let cachedAction = await commandCache.value(forKey: key) else { continue }
             if cachedAction.isContradicted(by: item) {
                 await commandCache.removeValue(forKey: key)
-                deadKeys.insert(key)
                 invalidatedActions.append(cachedAction)
-            }
-        }
-
-        if !deadKeys.isEmpty {
-            keysByEntity[item.entityId]?.subtract(deadKeys)
-            if keysByEntity[item.entityId]?.isEmpty == true {
-                keysByEntity[item.entityId] = nil
             }
         }
 

--- a/Sources/HAModels/HomeManagableAction+Contradiction.swift
+++ b/Sources/HAModels/HomeManagableAction+Contradiction.swift
@@ -1,0 +1,95 @@
+//
+//  HomeManagableAction+Contradiction.swift
+//  HomeAutomation
+//
+//  Created by Claude Code on 21.06.26.
+//
+
+import Foundation
+
+extension HomeManagableAction {
+    /// Tolerance for normalized `0...1` float fields (color temperature, RGB saturation).
+    /// Chosen above the 2-decimal granularity applied by ``rounded()`` so that a confirming
+    /// device read-back — which HomeKit additionally quantizes — is never mistaken for drift.
+    static let floatTolerance: Float = 0.02
+
+    /// Tolerance, in degrees, for the circular hue comparison of ``setRGB`` actions.
+    static let hueTolerance: Float = 6
+
+    /// Returns `true` when `item` is a freshly observed device state that *contradicts* this
+    /// previously-commanded action — i.e. the device drifted away from what the server last
+    /// commanded (for example a scene activated outside the server, or a manual change).
+    ///
+    /// Returns `false` when:
+    /// - the relevant state field is `nil` — an update about a different characteristic carries no
+    ///   information about this command and must never invalidate it;
+    /// - the field *confirms* the command. This is the crucial case: when the server issues a
+    ///   command, HomeKit echoes the resulting change back; that echo confirms the command and must
+    ///   not invalidate it, otherwise the command would be re-issued in a loop;
+    /// - the action has no observable live characteristic (``addEntityToScene``).
+    ///
+    /// - Parameter item: A freshly observed state for the same entity as this action.
+    /// - Returns: `true` if the state contradicts the command and the cache entry should be reset.
+    /// - Precondition: `item.entityId == self.entityId` (guaranteed by the caller).
+    /// - Note: `self` is expected to be the value as cached, i.e. already passed through ``rounded()``.
+    public func isContradicted(by item: EntityStorageItem) -> Bool {
+        switch self {
+        case .turnOn:
+            guard let isOn = item.isDeviceOn else { return false }
+            return isOn == false
+
+        case .turnOff:
+            guard let isOn = item.isDeviceOn else { return false }
+            return isOn == true
+
+        case .lockDoor:
+            guard let isLocked = item.isDoorLocked else { return false }
+            return isLocked == false
+
+        case .setHeating(_, let active):
+            guard let isHeating = item.isHeaterActive else { return false }
+            return isHeating != active
+
+        case .setValve(_, let active):
+            guard let isOpen = item.valveOpen else { return false }
+            return isOpen != active
+
+        case .setBrightness(_, let value):
+            // The action value is normalized `0...1`; the stored brightness is an `Int` percentage
+            // `0...100`. The adapter truncates when writing to the device, so allow a 1-point band.
+            guard let brightness = item.brightness else { return false }
+            let commandedPercent = Int((value * 100).rounded())
+            return abs(brightness - commandedPercent) > 1
+
+        case .setColorTemperature(_, let value):
+            // Both the action value and the stored value are normalized `0...1` (warm...cold).
+            guard let colorTemperature = item.colorTemperature else { return false }
+            return abs(colorTemperature - value) > Self.floatTolerance
+
+        case .setRGB(_, let rgb):
+            // `setRGB` only writes hue + saturation; the stored color reconstructs RGB using the
+            // device's *current* brightness, so comparing raw channels would couple to brightness.
+            // Compare in hue/saturation space instead, ignoring hue for near-greys (undefined hue).
+            guard let color = item.color else { return false }
+            let target = hsv(from: rgb)
+            let actual = hsv(from: color)
+
+            // When the device reads back as essentially black (off / brightness 0) the reported
+            // hue and saturation are meaningless — treat as no information rather than drift.
+            guard actual.v > Self.floatTolerance else { return false }
+
+            if abs(target.s - actual.s) > Self.floatTolerance { return true }
+
+            if target.s > Self.floatTolerance, actual.s > Self.floatTolerance {
+                let diff = abs(target.h - actual.h)
+                return min(diff, 360 - diff) > Self.hueTolerance
+            }
+            return false
+
+        case .addEntityToScene:
+            // Scene authoring, not a live device characteristic: there is nothing to compare
+            // against. Such entries are only ever expired via the cache TTL.
+            return false
+        }
+    }
+}

--- a/Sources/Shared/Cache.swift
+++ b/Sources/Shared/Cache.swift
@@ -13,10 +13,20 @@ public actor Cache<Key: Hashable & Sendable, Value: Sendable> {
     private let wrapped = NSCache<WrappedKey, Entry>()
     private let dateProvider: @Sendable () -> Date
     private let entryLifetime: TimeInterval?
+    /// Tracks the currently-live keys so callers can enumerate them — `NSCache` cannot.
+    /// The article uses an `NSCacheDelegate` (`KeyTracker`) for this; under Swift 6 strict
+    /// concurrency that delegate callback would mutate the set off the actor (data race), so we
+    /// instead keep an actor-isolated set maintained in `insert`/`removeValue` and pruned lazily in
+    /// `value(forKey:)` (covers both expiry and memory-pressure eviction by `NSCache`).
+    private var trackedKeys: Set<Key> = []
+
+    /// Snapshot of the keys currently held by the cache (best-effort: a key whose entry `NSCache`
+    /// evicted under memory pressure is pruned the next time it is looked up via `value(forKey:)`).
+    public var keys: Set<Key> { trackedKeys }
 
     /// Convenience initializer that accepts Duration
     public init(dateProvider: @escaping @Sendable () -> Date = Date.init,
-         entryLifetime: Duration? = nil) {
+                entryLifetime: Duration? = nil) {
         self.dateProvider = dateProvider
         self.entryLifetime = entryLifetime?.timeInterval
     }
@@ -30,10 +40,13 @@ public actor Cache<Key: Hashable & Sendable, Value: Sendable> {
             entry = Entry(key: key, value: value, expirationDate: nil)
         }
         wrapped.setObject(entry, forKey: WrappedKey(key))
+        trackedKeys.insert(key)
     }
 
     public func value(forKey key: Key) -> Value? {
         guard let entry = wrapped.object(forKey: WrappedKey(key)) else {
+            // Entry is gone (e.g. evicted by NSCache under memory pressure) — keep the index tight.
+            trackedKeys.remove(key)
             return nil
         }
 
@@ -52,6 +65,7 @@ public actor Cache<Key: Hashable & Sendable, Value: Sendable> {
 
     public func removeValue(forKey key: Key) {
         wrapped.removeObject(forKey: WrappedKey(key))
+        trackedKeys.remove(key)
     }
 
     public subscript(key: Key) -> Value? {

--- a/Tests/HomeAutomationKitTests/ActionLogManagerTests.swift
+++ b/Tests/HomeAutomationKitTests/ActionLogManagerTests.swift
@@ -1,0 +1,111 @@
+//
+//  ActionLogManagerTests.swift
+//  HomeAutomationKit
+//
+//  Created by Claude Code on 21.06.26.
+//
+
+import Foundation
+@testable import HAApplicationLayer
+import HAModels
+import Testing
+
+struct ActionLogManagerTests {
+
+    private let switchId = EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher)
+    private let brightnessId = EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .brightness)
+
+    @Test("Confirming echo does not invalidate — dedup is preserved (no command storm)")
+    func echoPreservesDedup() async {
+        let manager = ActionLogManager()
+        let action = HomeManagableAction.turnOn(switchId)
+
+        #expect(await manager.log(action: action) == false) // first call: miss → cached
+
+        let echo = EntityStorageItem(entityId: switchId, isDeviceOn: true)
+        let invalidated = await manager.invalidateContradictedCommands(for: echo)
+        #expect(invalidated.isEmpty)
+
+        #expect(await manager.log(action: action) == true) // still deduped
+    }
+
+    @Test("Contradicting state invalidates — command may be re-issued")
+    func driftInvalidates() async {
+        let manager = ActionLogManager()
+        let action = HomeManagableAction.turnOn(switchId)
+
+        #expect(await manager.log(action: action) == false)
+
+        let drift = EntityStorageItem(entityId: switchId, isDeviceOn: false)
+        let invalidated = await manager.invalidateContradictedCommands(for: drift)
+        #expect(invalidated == [action])
+
+        #expect(await manager.log(action: action) == false) // re-issue allowed (cache miss)
+    }
+
+    @Test("setBrightness echo preserves dedup, drift invalidates")
+    func brightnessDrift() async {
+        let manager = ActionLogManager()
+        let action = HomeManagableAction.setBrightness(brightnessId, 0.5)
+
+        #expect(await manager.log(action: action) == false)
+
+        // echo of the commanded value (50%) confirms → kept
+        let echo = EntityStorageItem(entityId: brightnessId, brightness: 50)
+        #expect(await manager.invalidateContradictedCommands(for: echo).isEmpty)
+        #expect(await manager.log(action: action) == true)
+
+        // a real drift to 10% contradicts → invalidated
+        let drift = EntityStorageItem(entityId: brightnessId, brightness: 10)
+        #expect(await manager.invalidateContradictedCommands(for: drift) == [action])
+        #expect(await manager.log(action: action) == false)
+    }
+
+    @Test("State change for an entity with no cached command is a no-op")
+    func noCachedCommand() async {
+        let manager = ActionLogManager()
+        let drift = EntityStorageItem(entityId: switchId, isDeviceOn: false)
+        #expect(await manager.invalidateContradictedCommands(for: drift).isEmpty)
+    }
+
+    @Test("Only the contradicted command is reset; others for the same entity survive")
+    func onlyContradictedIsReset() async {
+        let manager = ActionLogManager()
+        let onAction = HomeManagableAction.turnOn(switchId)
+        let brightnessAction = HomeManagableAction.setBrightness(switchId, 0.5)
+
+        #expect(await manager.log(action: onAction) == false)
+        #expect(await manager.log(action: brightnessAction) == false)
+
+        // Only the power state drifted (off); brightness is unknown in this update.
+        let drift = EntityStorageItem(entityId: switchId, isDeviceOn: false)
+        let invalidated = await manager.invalidateContradictedCommands(for: drift)
+        #expect(invalidated == [onAction])
+
+        // turnOn may be re-issued, setBrightness is still deduped.
+        #expect(await manager.log(action: onAction) == false)
+        #expect(await manager.log(action: brightnessAction) == true)
+    }
+
+    @Test("Expired cache entries are dropped and the index self-heals")
+    func indexPrunedOnExpiry() async {
+        final class DateHolder: @unchecked Sendable {
+            var currentDate = Date()
+        }
+        let holder = DateHolder()
+        let manager = ActionLogManager(dateProvider: { holder.currentDate })
+        let action = HomeManagableAction.turnOn(switchId)
+
+        #expect(await manager.log(action: action) == false)
+
+        // Advance past the 2-minute TTL so the cache entry expires.
+        holder.currentDate = holder.currentDate.addingTimeInterval(121)
+
+        // The contradicting state finds nothing to invalidate (entry already expired).
+        let drift = EntityStorageItem(entityId: switchId, isDeviceOn: false)
+        #expect(await manager.invalidateContradictedCommands(for: drift).isEmpty)
+
+        // Dedup is gone (expired) → the command is a fresh miss again.
+        #expect(await manager.log(action: action) == false)
+    }
+}

--- a/Tests/HomeAutomationKitTests/HomeManagableActionContradictionTests.swift
+++ b/Tests/HomeAutomationKitTests/HomeManagableActionContradictionTests.swift
@@ -1,0 +1,144 @@
+//
+//  HomeManagableActionContradictionTests.swift
+//  HomeAutomationKit
+//
+//  Created by Claude Code on 21.06.26.
+//
+
+import Foundation
+@testable import HAModels
+import Testing
+
+struct HomeManagableActionContradictionTests {
+
+    private func entityId(_ characteristic: CharacteristicsType) -> EntityId {
+        EntityId(placeId: "room", name: "device", characteristicsName: nil, characteristic: characteristic)
+    }
+
+    // MARK: - turnOn / turnOff
+
+    @Test("turnOn: off contradicts, on confirms, nil is no-op")
+    func turnOn() {
+        let id = entityId(.switcher)
+        let action = HomeManagableAction.turnOn(id)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: false)) == true)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: true)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: nil)) == false)
+    }
+
+    @Test("turnOff: on contradicts, off confirms, nil is no-op")
+    func turnOff() {
+        let id = entityId(.switcher)
+        let action = HomeManagableAction.turnOff(id)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: true)) == true)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: false)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: nil)) == false)
+    }
+
+    // MARK: - lockDoor
+
+    @Test("lockDoor: unlocked contradicts, locked confirms, nil is no-op")
+    func lockDoor() {
+        let id = entityId(.lock)
+        let action = HomeManagableAction.lockDoor(id)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDoorLocked: false)) == true)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDoorLocked: true)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDoorLocked: nil)) == false)
+    }
+
+    // MARK: - setHeating
+
+    @Test("setHeating(active): mismatch contradicts, match confirms, nil is no-op")
+    func setHeating() {
+        let id = entityId(.heating)
+        let activeAction = HomeManagableAction.setHeating(id, active: true)
+        #expect(activeAction.isContradicted(by: EntityStorageItem(entityId: id, isHeaterActive: false)) == true)
+        #expect(activeAction.isContradicted(by: EntityStorageItem(entityId: id, isHeaterActive: true)) == false)
+        #expect(activeAction.isContradicted(by: EntityStorageItem(entityId: id, isHeaterActive: nil)) == false)
+
+        let inactiveAction = HomeManagableAction.setHeating(id, active: false)
+        #expect(inactiveAction.isContradicted(by: EntityStorageItem(entityId: id, isHeaterActive: true)) == true)
+        #expect(inactiveAction.isContradicted(by: EntityStorageItem(entityId: id, isHeaterActive: false)) == false)
+    }
+
+    // MARK: - setValve
+
+    @Test("setValve(active): mismatch contradicts, match confirms, nil is no-op")
+    func setValve() {
+        let id = entityId(.valve)
+        let openAction = HomeManagableAction.setValve(id, active: true)
+        #expect(openAction.isContradicted(by: EntityStorageItem(entityId: id, valveOpen: false)) == true)
+        #expect(openAction.isContradicted(by: EntityStorageItem(entityId: id, valveOpen: true)) == false)
+        #expect(openAction.isContradicted(by: EntityStorageItem(entityId: id, valveOpen: nil)) == false)
+    }
+
+    // MARK: - setBrightness (Float 0...1 action vs Int 0...100 state, ±1 band)
+
+    @Test("setBrightness: within ±1 point confirms, beyond contradicts, nil is no-op")
+    func setBrightness() {
+        let id = entityId(.brightness)
+        let action = HomeManagableAction.setBrightness(id, 0.5) // commanded 50%
+        // confirming band 49/50/51
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, brightness: 49)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, brightness: 50)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, brightness: 51)) == false)
+        // beyond the band
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, brightness: 48)) == true)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, brightness: 52)) == true)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, brightness: 10)) == true)
+        // no information
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, brightness: nil)) == false)
+    }
+
+    // MARK: - setColorTemperature (normalized 0...1, 0.02 tolerance)
+
+    @Test("setColorTemperature: within tolerance confirms, beyond contradicts, nil is no-op")
+    func setColorTemperature() {
+        let id = entityId(.colorTemperature)
+        let action = HomeManagableAction.setColorTemperature(id, 0.30)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, colorTemperature: 0.30)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, colorTemperature: 0.31)) == false) // 0.01 ≤ 0.02
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, colorTemperature: 0.34)) == true)  // 0.04 > 0.02
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, colorTemperature: 0.90)) == true)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, colorTemperature: nil)) == false)
+    }
+
+    // MARK: - setRGB (hue/saturation space, brightness-decoupled)
+
+    @Test("setRGB: same color confirms, different hue contradicts, nil is no-op")
+    func setRGBHue() {
+        let id = entityId(.color)
+        let red = RGB(red: 1, green: 0, blue: 0)
+        let blue = RGB(red: 0, green: 0, blue: 1)
+        let action = HomeManagableAction.setRGB(id, rgb: red)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, color: red)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, color: blue)) == true)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, color: nil)) == false)
+    }
+
+    @Test("setRGB: saturation drift contradicts")
+    func setRGBSaturation() {
+        let id = entityId(.color)
+        let saturatedRed = RGB(red: 1, green: 0, blue: 0)
+        let pale = RGB(red: 1, green: 0.8, blue: 0.8) // same hue, much lower saturation
+        let action = HomeManagableAction.setRGB(id, rgb: saturatedRed)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, color: pale)) == true)
+    }
+
+    @Test("setRGB: near-black read-back is treated as no information")
+    func setRGBBlackIsNoOp() {
+        let id = entityId(.color)
+        let action = HomeManagableAction.setRGB(id, rgb: RGB(red: 1, green: 0, blue: 0))
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, color: RGB(red: 0, green: 0, blue: 0))) == false)
+    }
+
+    // MARK: - addEntityToScene (no live characteristic)
+
+    @Test("addEntityToScene: never contradicted")
+    func addEntityToScene() {
+        let id = entityId(.switcher)
+        let action = HomeManagableAction.addEntityToScene(id, sceneName: "goodNight", targetValue: .off)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: true)) == false)
+        #expect(action.isContradicted(by: EntityStorageItem(entityId: id, isDeviceOn: false)) == false)
+    }
+}


### PR DESCRIPTION
## Context

`HomeManager.perform(_:)` deduplicates outgoing HomeKit commands through a 2-minute cache (`ActionLogManager.commandCache`, keyed by `"<entityId>-<actionName>"`). On a cache hit it logs *"Skipping duplicate command"* and **does not execute**.

That is correct while the device stays in the commanded state, but becomes a bug when the device drifts away through a path the server didn't initiate — most importantly a **scene activated from outside the server** (Home app / Siri / a physical button), but also a manual toggle. Example: an automation cached `turnOn(light)`; a "good night" scene then turns the light off; the automation re-evaluates, wants the light on, but the cache still holds `turnOn` → the command stays suppressed and the light stays off until the 2-minute TTL expires.

**Goal:** when the adapter reports a real state change that *contradicts* a cached command, reset that cache entry so the automation engine may re-issue it.

## Approach

State-aware invalidation at the incoming-state path. The cache entry is reset **only when the new state contradicts the command**, never when it confirms it.

This distinction is essential: when the server itself issues a command, HomeKit echoes the resulting change back into `addEntityHistory`, and `EventProcessingJob` runs `addEntityHistory` *then* re-evaluates automations on that same event. A naive "invalidate on any change" would wipe the entry the command just created and let a level-triggered automation re-issue it immediately → a command storm. The confirming echo is *not* a contradiction, so dedup is preserved and no loop occurs.

### Changes
- **`HomeManagableAction.isContradicted(by:)`** (new `Sources/HAModels/HomeManagableAction+Contradiction.swift`) — per-case predicate over all 9 actions.
  - `nil`/unknown fields → not contradicted (an update about a different characteristic carries no information).
  - Confirming value → not contradicted (the echo case).
  - `setBrightness`: normalized `0...1` action vs `Int` 0–100 state, ±1-point band absorbs the adapter's truncation.
  - `setColorTemperature`: both normalized `0...1`, `0.02` tolerance.
  - `setRGB`: compared in **hue/saturation space** (the dimensions the adapter actually writes), decoupled from device brightness; near-black read-backs are treated as no information.
  - `addEntityToScene`: never contradicted (no live characteristic; TTL only).
- **`ActionLogManager`** — a `keysByEntity` index (NSCache can't enumerate keys) and `invalidateContradictedCommands(for:)`, which removes contradicted entries and prunes expired keys. `init` gains an injectable `dateProvider` for testing.
- **`HomeManager.addEntityHistory`** — calls the invalidation synchronously (before the detached DB persist) so the cache is already reset when the automation re-evaluates the same event.
- **`trigger(scene:)`** — unchanged; a comment documents why (scene effects, external or server-triggered, arrive as per-entity echoes handled by the path above).

## Tests
- **Predicate** — all 9 cases: nil-safety, confirming echo, drift, and tolerance boundaries (`setBrightness` 49/50/51 vs 48/52; `setColorTemperature` ±tolerance; `setRGB` hue/saturation/near-black).
- **ActionLogManager** — confirming echo preserves dedup (no storm), contradiction invalidates and allows re-issue, only the contradicted command is reset, no-cached-command is a no-op, and the index self-heals after TTL expiry.

## Verification
- `swiftlint --fix && swiftlint` — clean.
- `swift build` — clean (only pre-existing TCA deprecation warnings).
- `swift test` — all 17 new tests pass; full suite green **except** a pre-existing `ControllerTests` SIGSEGV in the swift-testing helper that reproduces identically on a clean `develop` tree (Xcode 27 beta toolchain), unrelated to this change.

> ⚠️ The iOS app Xcode builds could not be validated locally: both fail on a clean `develop` checkout for environmental reasons unrelated to this change — **Adapter**: `cannot find 'CustomActorSystem' in scope` (SharedDistributedCluster module resolution in the Xcode project); **Controller**: package-plugin / Swift-macro trust prompts and SwiftSyntax resolution under the Xcode 27 beta toolchain. The SPM `swift build` (which compiles the same module sources) is green; CI runs the iOS app builds on this PR.