### PR TITLE
CI: fail pipelines on real build errors

### DIFF
--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -25,8 +25,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"
-          PREV_TAG=$(git tag --sort=-v:refname | grep -A1 "^$TAG$" | tail -1)
+          # `|| true`: a missing previous tag is a valid outcome here, not an error.
+          PREV_TAG=$(git tag --sort=-v:refname | grep -A1 "^$TAG$" | tail -1 || true)
 
           if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
             NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Check Package.resolved is up to date for ${{ matrix.app.name }}
         working-directory: ${{ matrix.app.path }}
         run: |
+          set -euo pipefail
           # Resolve dependencies to update Package.resolved
           xcodebuild \
             -project "${{ matrix.app.project }}" \
@@ -76,6 +77,7 @@ jobs:
       - name: Build ${{ matrix.app.name }}
         working-directory: ${{ matrix.app.path }}
         run: |
+          set -euo pipefail
           xcodebuild \
             -project "${{ matrix.app.project }}" \
             -scheme "${{ matrix.app.scheme }}" \
@@ -83,7 +85,7 @@ jobs:
             -configuration Debug \
             -derivedDataPath .build \
             clean build \
-            | xcpretty || true
+            | xcbeautify
 
   docker:
     name: Docker Build

--- a/.github/workflows/renovate-package-resolved.yaml
+++ b/.github/workflows/renovate-package-resolved.yaml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Resolve package dependencies for iOS apps
         run: |
+          set -euo pipefail
           cd "Apps/FlowKitAdapter" && xcodebuild -project "FlowKit Adapter.xcodeproj" -scheme "FlowKit Adapter" -resolvePackageDependencies
           cd ../..
           cd "Apps/FlowKitController" && xcodebuild -project "FlowKit Controller.xcodeproj" -scheme "FlowKit Controller" -resolvePackageDependencies
@@ -31,6 +32,7 @@ jobs:
       - name: Check for changes in Package.resolved
         id: changes
         run: |
+          set -euo pipefail
           if git diff --quiet Package.resolved "Apps/FlowKitAdapter/FlowKit Adapter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved" "Apps/FlowKitController/FlowKit Controller.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
@@ -40,6 +42,7 @@ jobs:
       - name: Commit Package.resolved changes
         if: steps.changes.outputs.changed == 'true'
         run: |
+          set -euo pipefail
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add Package.resolved "Apps/FlowKitAdapter/FlowKit Adapter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved" "Apps/FlowKitController/FlowKit Controller.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"


### PR DESCRIPTION
## Problem

The `iOS Apps Build` job in `pr-checks.yml` ran:

```yaml
xcodebuild ... clean build | xcpretty || true
```

The trailing `|| true` forces the step to exit 0 **regardless of the build result**, so the job reports green even when an app fails to compile. As a result the FlowKit Adapter has been failing to build in Xcode Cloud for many builds while the GitHub PR check stayed green and never blocked the offending PRs.

## Fix

- **`pr-checks.yml`** — remove `| xcpretty || true`; pipe to `xcbeautify` (maintained, pre-installed on the macOS runners) under `set -euo pipefail` so a non-zero `xcodebuild` exit propagates through the pipe and the job goes **red**.
- **All workflows** — add explicit `set -euo pipefail` to every multi-line `run:` block (`pr-checks.yml`, `docker-tag.yaml`, `renovate-package-resolved.yaml`) so failure detection no longer depends solely on GitHub's default shell flags.
- The release-notes step keeps a deliberate `|| true` on the `grep` for the previous tag, because *no previous tag* is a valid outcome there (not an error). Documented inline.

Docker jobs already fail correctly (the `docker/build-push-action` surfaces build errors), so no change was needed there.

## Note

This PR only makes CI **report** failures correctly. The actual FlowKit Adapter compile error (missing `import SharedDistributedCluster` after #183 moved the types) is fixed in a separate follow-up PR.