### PR TITLE
CI: run ci_post_clone.sh so iOS builds trust plugins & macros

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -88,12 +88,17 @@ jobs:
         working-directory: ${{ matrix.app.path }}
         run: |
           set -euo pipefail
+          # SWIFT_ENABLE_EXPLICIT_MODULES=NO: work around an Xcode 26 regression where
+          # explicit modules + the downloaded swift-syntax macro prebuilt break macro
+          # dependency resolution (FlowKitController: "unable to resolve module
+          # dependency: 'SwiftSyntax'" while building PerceptionMacros).
           xcodebuild \
             -project "${{ matrix.app.project }}" \
             -scheme "${{ matrix.app.scheme }}" \
             -sdk iphonesimulator \
             -configuration Debug \
             -derivedDataPath .build \
+            SWIFT_ENABLE_EXPLICIT_MODULES=NO \
             clean build \
             | xcbeautify
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,6 +74,16 @@ jobs:
             exit 1
           fi
 
+      - name: Trust package plugins & macros for ${{ matrix.app.name }}
+        # GitHub Actions does not run the Xcode Cloud ci_scripts, so reuse the existing
+        # ci_post_clone.sh here. It writes ~/Library/org.swift.swiftpm/security/macros.json
+        # and sets IDESkipPackagePluginFingerprintValidatation so the OpenAPIGenerator
+        # build-tool plugin and the TCA / swift-dependencies macros are trusted non-
+        # interactively. Without this the FlowKitController build fails on CI with
+        # "Validate plug-in 'OpenAPIGenerator'".
+        working-directory: ${{ matrix.app.path }}/ci_scripts
+        run: ./ci_post_clone.sh
+
       - name: Build ${{ matrix.app.name }}
         working-directory: ${{ matrix.app.path }}
         run: |


### PR DESCRIPTION
## Problem
After #185 stopped masking iOS build failures, the **FlowKitController** iOS build is red on GitHub Actions:

```
Validate plug-in 'OpenAPIGenerator' in package 'swift-openapi-generator'
** BUILD FAILED **
```

**Pre-existing** — hidden by the old `| xcpretty || true`. The Controller depends on `ServerClient`, which runs the **OpenAPIGenerator build-tool plugin**; CI requires plugin/macro fingerprint validation.

The repo *already* solves this for **Xcode Cloud** via `Apps/<App>/ci_scripts/ci_post_clone.sh` (it writes `~/Library/org.swift.swiftpm/security/macros.json` and sets `IDESkipPackagePluginFingerprintValidatation`). But **GitHub Actions never runs the `ci_scripts`** — they're Xcode Cloud lifecycle hooks — so on GitHub's runners the plugins/macros were never trusted. FlowKitAdapter has no such plugin, which is why only the Controller failed.

## Fix
Reuse the existing script: add a workflow step that runs `ci_post_clone.sh` before each app build. No duplicated trust logic — single source of truth shared with Xcode Cloud.

## Related
- #185 un-masked these failures.
- #186 fixes the FlowKitAdapter (missing `import SharedDistributedCluster`); it goes fully green once this merges and it's rebased.