### PR TITLE
Drop the obsolete swift-log <1.13 Renovate hold

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,12 +9,6 @@
     {
       "matchManagers": ["swift"],
       "rangeStrategy": "bump"
-    },
-    {
-      "description": "Hold apple/swift-log below 1.13: its source-breaking MetadataValue string-interpolation change breaks swift-cluster-membership (transitive via swift-distributed-actors). Remove once distributed-actors/cluster-membership builds against swift-log 1.13.",
-      "matchManagers": ["swift"],
-      "matchPackageNames": ["apple/swift-log", "https://github.com/apple/swift-log.git"],
-      "allowedVersions": "<1.13.0"
     }
   ]
 }


### PR DESCRIPTION
## Warum

Die Renovate-Regel hält `apple/swift-log` auf `<1.13.0`. Begründung laut ihrer eigenen `description`:

> its source-breaking MetadataValue string-interpolation change breaks swift-cluster-membership (transitive via swift-distributed-actors)

Dieser Grund besteht nicht mehr: seit #193 (`Replace DistributedCluster with minimal WebSocket-based StarActorSystem`) ist `swift-distributed-actors` raus. Weder `swift-distributed-actors` noch `swift-cluster-membership` taucht noch in `Package.swift` oder `Package.resolved` auf.

## Was

Entfernt die `allowedVersions: "<1.13.0"`-Regel aus `renovate.json`. Sonst nichts — `Package.swift` bleibt unverändert bei swift-log 1.12.1; den eigentlichen Bump schlägt Renovate im nächsten Lauf selbst vor.

## Verifikation

Lokal gegen **swift-log 1.14.0** (aktuell neueste Version) geprüft, indem der Pin testweise hochgezogen wurde:

- `swift package resolve` ✅
- `swift build` ✅ (Build complete)
- `swift test` ✅ — 122 Tests in 22 Suites bestanden

Die Teständerung an `Package.swift` wurde danach zurückgenommen; dieser PR enthält nur die `renovate.json`-Änderung.

Gefunden bei der Arbeit an #187.