### PR TITLE
Stop HomeKit rescan floods from cancelling automations mid-command

### DIFF
--- a/Sources/Adapter/HomeKitAdapter+Delegates.swift
+++ b/Sources/Adapter/HomeKitAdapter+Delegates.swift
@@ -9,6 +9,7 @@
 import HAModels
 import HomeKit
 import Logging
+import Shared
 
 extension HomeKitAdapter {
     final class HomeKitHomeManager: NSObject, @unchecked Sendable {
@@ -24,12 +25,21 @@ extension HomeKitAdapter {
         let entityStream: AsyncStream<EntityStorageItem>
         private let entityStreamContinuation: AsyncStream<EntityStorageItem>.Continuation
 
+        /// The only path that runs `updateEntities()`. A single reachability flap makes HomeKit fire
+        /// a burst of delegate callbacks, and each one would otherwise start a full rescan that
+        /// re-yields every entity; the debouncer collapses the burst and keeps rescans from
+        /// overlapping. Assigned before the delegates so no callback can find it missing.
+        private var entityUpdateDebouncer: AsyncDebouncer!
+
         init(entityStream: AsyncStream<EntityStorageItem>, entityStreamContinuation: AsyncStream<EntityStorageItem>.Continuation) {
             self.entityStream = entityStream
             self.entityStreamContinuation = entityStreamContinuation
 
             manager = HMHomeManager()
             super.init()
+            entityUpdateDebouncer = AsyncDebouncer(delay: .seconds(5)) { [weak self] in
+                await self?.updateEntities()
+            }
             manager.delegate = self
 
             // the connection to HomeKit seems to breake after x hours (e.g. no delegates will be called anymore), we try to reset the connection to avoid interruptions
@@ -63,7 +73,18 @@ extension HomeKitAdapter {
             }
         }
 
-        func updateEntities() async {
+        /// Request a full entity refresh after the debounce delay.
+        func scheduleEntityUpdate() async {
+            await entityUpdateDebouncer.schedule()
+        }
+
+        /// Request a full entity refresh without waiting for the debounce delay — a reconnect resync
+        /// must not be deferred or coalesced away — but still serialized against a running refresh.
+        func updateEntitiesNow() async {
+            await entityUpdateDebouncer.runNow()
+        }
+
+        private func updateEntities() async {
             let start = ContinuousClock.now
             let homes = await homesPublisher.get()
 
@@ -80,7 +101,10 @@ extension HomeKitAdapter {
             var subscriptionErrors = 0
             for characteristic in allCharacteristics.sorted() {
                 guard let accessory = characteristic.service?.accessory else {
-                    fatalError("Could not set delegate on accessory")
+                    // The back-reference can be transiently nil while HomeKit re-builds its object
+                    // graph; the next rescan picks the characteristic up again.
+                    log.error("Could not set delegate on accessory of characteristic \(characteristic.uniqueIdentifier.uuidString)")
+                    continue
                 }
 
                 accessory.delegate = self
@@ -131,12 +155,11 @@ extension HomeKitAdapter {
                 home.delegate = self
             }
 
+            // `homesPublisher` stays immediate: `getAllEntitiesLive()` and `perform(_:)` read the
+            // homes through it, and its first value unblocks callers that are already waiting.
             Task {
-                let start = ContinuousClock.now
                 await homesPublisher.send(homes)
-                await updateEntities()
-                let duration = start.duration(to: .now)
-                log.info("update(homes:) — completed in \(duration)")
+                await scheduleEntityUpdate()
             }
         }
 

--- a/Sources/Adapter/HomeKitAdapter.swift
+++ b/Sources/Adapter/HomeKitAdapter.swift
@@ -35,10 +35,11 @@ public final class HomeKitAdapter: HomeKitAdapterable {
     ///
     /// Used after a (re)connect to the server so it never misses state changes
     /// that happened while the link was down. Reuses the existing full-refresh
-    /// path (`updateEntities()`), which also re-checks characteristic subscriptions.
+    /// path, which also re-checks characteristic subscriptions — undelayed, but
+    /// serialized against a refresh that is already running.
     public func pushFullState() async {
         log.info("pushFullState() — re-yielding full entity state after (re)connect")
-        await homeKitHomeManager.updateEntities()
+        await homeKitHomeManager.updateEntitiesNow()
     }
 
     public func getAllEntitiesLive() async -> [EntityStorageItem] {
@@ -80,9 +81,11 @@ public final class HomeKitAdapter: HomeKitAdapterable {
         let filteredCharacteristics = characteristics.filter({ $0.entityId == action.entityId })
         guard filteredCharacteristics.count == 1,
               let characteristic = filteredCharacteristics.first else {
-            log.error("Failed to get characteristic")
-            assertionFailure()
-            return
+            // Must throw, not return: a silent success would let the server mark the command as
+            // executed and dedup every retry of it. Reachable whenever the homes list is
+            // transiently empty (e.g. during the 6h HMHomeManager reset).
+            log.error("Failed to get characteristic for \(action.entityId)")
+            throw OptionalError.notFound
         }
         log.info("Perform action [\(action)] on [\(characteristic)]")
 
@@ -98,8 +101,8 @@ public final class HomeKitAdapter: HomeKitAdapterable {
             assert((0.0...1.0).contains(value), "Value (\(value) out of bounds")
             guard let minimumValue = characteristic.metadata?.minimumValue,
                   let maximumValue = characteristic.metadata?.maximumValue else {
-                assertionFailure()
-                return
+                log.error("Failed to get brightness bounds of \(action.entityId)")
+                throw OptionalError.notFound
             }
             let adjustedValue = Float(truncating: minimumValue) + value * (Float(truncating: maximumValue) - Float(truncating: minimumValue))
             newValue = NSNumber(value: Int64(adjustedValue))
@@ -108,8 +111,8 @@ public final class HomeKitAdapter: HomeKitAdapterable {
             assert((0.0...1.0).contains(value), "Value (\(value) out of bounds")
             guard let minimumValue = characteristic.metadata?.minimumValue,
                   let maximumValue = characteristic.metadata?.maximumValue else {
-                assertionFailure()
-                return
+                log.error("Failed to get color temperature bounds of \(action.entityId)")
+                throw OptionalError.notFound
             }
 
             let adjustedValue = Float(truncating: minimumValue) + (1 - value) * (Float(truncating: maximumValue) - Float(truncating: minimumValue))
@@ -128,8 +131,7 @@ public final class HomeKitAdapter: HomeKitAdapterable {
         case .addEntityToScene(_, sceneName: let sceneName, let action):
             guard let home = characteristic.service?.accessory?.home else {
                 log.error("Failed to get home for characteristic")
-                assertionFailure()
-                return
+                throw OptionalError.notFound
             }
 
             // create scene if not exists
@@ -138,8 +140,7 @@ public final class HomeKitAdapter: HomeKitAdapterable {
             }
             guard let scene = home.actionSets.first(where: { $0.name == sceneName }) else {
                 log.error("Could not find scene named \(sceneName)")
-                assertionFailure()
-                return
+                throw OptionalError.notFound
             }
 
             // add action if not exists

--- a/Sources/HAApplicationLayer/HomeManager.swift
+++ b/Sources/HAApplicationLayer/HomeManager.swift
@@ -12,6 +12,9 @@ import Shared
 
 @HomeManagerActor
 public final class HomeManager: HomeManagable {
+    /// Number of times a command is sent to the adapter before it is dropped.
+    nonisolated private static let maxAttempts = 3
+
     private let log = Logger(label: "HomeManager")
     private let windowManager: WindowManager
     private let actionLogManager: ActionLogManager
@@ -21,9 +24,15 @@ public final class HomeManager: HomeManagable {
     private let storageRepo: StorageRepository
     private let notificationSender: NotificationSender
     private let entityCache = Cache<EntityId, EntityStorageItem>(entryLifetime: .hours(2))
-    private var failedActions: [EntityId: HomeManagableAction] = [:]
+    /// One retry slot per entity: a newer failed action replaces an older queued one, so the newest
+    /// intent wins. `EntityId` carries the characteristic, so a lamp's brightness and color
+    /// temperature occupy separate slots; `turnOn` and `turnOff` share the switcher slot on purpose —
+    /// replaying both would be contradictory.
+    private var failedActions: [EntityId: (action: HomeManagableAction, attempt: Int)] = [:]
 
-    public init(getAdapter: @escaping () async -> (any EntityAdapterable)?, storageRepo: StorageRepository, notificationSender: NotificationSender, location: Location, actionLogManager: ActionLogManager) {
+    /// - Parameter retryTicks: Cadence at which queued failed actions are retried. Pass a stream to
+    ///   drive the retries deterministically; the default is a 5s timer.
+    public init(getAdapter: @escaping () async -> (any EntityAdapterable)?, storageRepo: StorageRepository, notificationSender: NotificationSender, location: Location, actionLogManager: ActionLogManager, retryTicks: AsyncStream<Void>? = nil) {
         self.windowManager = WindowManager(notificationSender: notificationSender)
         self.actionLogManager = actionLogManager
         self.getAdapter = getAdapter
@@ -41,16 +50,29 @@ public final class HomeManager: HomeManagable {
 //            }
 //        }
 
+        let ticks = retryTicks ?? Self.timerRetryTicks()
         Task.detached(priority: .low) {
-            for await _ in Timer.publish(every: .seconds(5)) {
-                let actions = await self.popAllFailedActions()
-                for action in actions {
-                    self.log.debug("Performing failed action again: \(action)")
-                    // skip adding this action again after a failed run
-                    await self.perform(action, addToFaliedActions: false)
+            for await _ in ticks {
+                let queued = await self.popAllFailedActions()
+                for (action, attempt) in queued {
+                    self.log.debug("Performing failed action again: \(action) [attempt \(attempt + 1)/\(Self.maxAttempts)]")
+                    await self.perform(action, attempt: attempt)
                 }
             }
         }
+    }
+
+    /// Production retry cadence: a tick every 5s (the shared timer aligns its first tick to the next
+    /// minute boundary).
+    private static func timerRetryTicks() -> AsyncStream<Void> {
+        let (stream, continuation) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        Task.detached(priority: .low) {
+            for await _ in Timer.publish(every: .seconds(5)) {
+                continuation.yield(())
+            }
+            continuation.finish()
+        }
+        return stream
     }
 
     public func getCurrentEntity(with entityId: EntityId) async throws -> EntityStorageItem {
@@ -84,11 +106,18 @@ public final class HomeManager: HomeManagable {
     public func perform(_ action: HomeManagableAction) async {
         // Round values to prevent excessive HomeKit updates
         let roundedAction = action.rounded()
-        // add errors to failed action in this first run from external source
-        await perform(roundedAction, addToFaliedActions: true)
+        await perform(roundedAction, attempt: 0)
     }
 
-    private func perform(_ action: HomeManagableAction, addToFaliedActions: Bool) async {
+    private func perform(_ action: HomeManagableAction, attempt: Int) async {
+        // Cancellation is honoured at command boundaries only: a superseded automation run must not
+        // start further commands, but a command that already started always runs to completion (see
+        // the shield below). Checked before logging so a skipped command produces no log entry.
+        guard !Task.isCancelled else {
+            log.debug("Skipping action of a cancelled run: [\(action)]")
+            return
+        }
+
         // Log action and check if it's a duplicate (cache hit)
         let hasCacheHit = await actionLogManager.log(action: action)
 
@@ -101,17 +130,30 @@ public final class HomeManager: HomeManagable {
         log.debug("Executing action: [\(action)]")
 
         do {
-            try await getAdapter().get(with: log).perform(action)
+            let adapter = try await getAdapter().get(with: log)
+
+            // Shield the in-flight command from the caller's cancellation: an unstructured task
+            // inherits priority, task locals and actor isolation but not cancellation, so a
+            // cancelled run can no longer abort the remote call mid-flight and leave a device half
+            // configured. The remote call brings its own timeout, so this cannot hang forever.
+            let command = Task { try await adapter.perform(action) }
+            try await command.value
+
+            // Only a command that reached the device may deduplicate its successors.
+            await actionLogManager.markExecuted(action)
         } catch {
             let entityId = action.entityId
 
             if let entity = try? await getCurrentEntity(with: entityId) {
                 log.error("(\(entityId)) entity \(entity)")
             }
-            log.error("(\(entityId)) Failed to perform action [\(action), addToFaliedActions: \(addToFaliedActions)]\n\(error)")
+            log.error("(\(entityId)) Failed to perform action [\(action), attempt: \(attempt + 1)/\(Self.maxAttempts)]\n\(error)")
 
-            if addToFaliedActions {
-                failedActions[entityId] = action
+            let nextAttempt = attempt + 1
+            if nextAttempt < Self.maxAttempts {
+                failedActions[entityId] = (action, nextAttempt)
+            } else {
+                log.critical("Giving up on action [\(action)] after \(Self.maxAttempts) attempts")
             }
         }
     }
@@ -220,9 +262,9 @@ public final class HomeManager: HomeManagable {
         await actionLogManager.clear()
     }
 
-    private func popAllFailedActions() -> [HomeManagableAction] {
-        let actions = Array(failedActions.values)
+    private func popAllFailedActions() -> [(action: HomeManagableAction, attempt: Int)] {
+        let queued = Array(failedActions.values)
         failedActions.removeAll()
-        return actions
+        return queued
     }
 }

--- a/Sources/HAApplicationLayer/HomeManager.swift
+++ b/Sources/HAApplicationLayer/HomeManager.swift
@@ -176,8 +176,21 @@ public final class HomeManager: HomeManagable {
         }
     }
 
-    public func addEntityHistory(_ item: EntityStorageItem) async {
+    @discardableResult
+    public func addEntityHistory(_ item: EntityStorageItem) async -> Bool {
         log.debug("Adding entity item to storage \(item.entityId)")
+
+        // `EntityStorageItem` is Equatable including its timestamp, so align it before comparing —
+        // only the values decide whether this is new information. An unknown entity counts as a
+        // change so nothing is ever swallowed on the first sighting.
+        let didChange: Bool
+        if var knownItem = await entityCache.value(forKey: item.entityId) {
+            knownItem.timestamp = item.timestamp
+            didChange = knownItem != item
+        } else {
+            didChange = true
+        }
+
         await entityCache.insert(item, forKey: item.entityId)
 
         // A freshly observed state can reveal that the device drifted away from what the server last
@@ -187,6 +200,12 @@ public final class HomeManager: HomeManagable {
         // same event right after — is allowed to re-issue it. A state that confirms the command (the
         // command's own echo) is not contradicted, so deduplication is preserved and no command loop
         // occurs. Done synchronously here so the cache is already reset before the automation runs.
+        //
+        // Invariant this relies on: no `.change`-triggered automation commands its own trigger
+        // entity. Today that holds (MotionAtNight triggers on motion/contact and commands lights,
+        // WindowOpen commands nothing). An automation that violated it would not get its command
+        // re-issued after the drift was healed, because the `didChange` gate above stops a
+        // value-identical replay from triggering the automation again.
         let invalidatedActions = await actionLogManager.invalidateContradictedCommands(for: item)
         if !invalidatedActions.isEmpty {
             log.info("Invalidated \(invalidatedActions.count) cached command(s) for \(item.entityId) due to state drift: \(invalidatedActions)")
@@ -211,6 +230,8 @@ public final class HomeManager: HomeManagable {
                 self.log.critical("Failed to persist entity item \(error)")
             }
         }
+
+        return didChange
     }
 
     public func maintenance() async throws {

--- a/Sources/HAApplicationLayer/Managers/ActionLogManager.swift
+++ b/Sources/HAApplicationLayer/Managers/ActionLogManager.swift
@@ -33,6 +33,11 @@ public actor ActionLogManager {
     }
 
     /// Log an action and check if it was a duplicate (cache hit)
+    ///
+    /// Logging alone does not deduplicate the action: only `markExecuted(_:)` does. A command that
+    /// never reached the device (cancelled, adapter error) must stay a cache miss so the next
+    /// attempt is allowed through.
+    ///
     /// - Parameter action: The action to log
     /// - Returns: true if this was a duplicate action (cache hit), false if it's a new action that should be executed
     public func log(action: HomeManagableAction) async -> Bool {
@@ -46,11 +51,6 @@ public actor ActionLogManager {
             hasCacheHit = (cachedAction == action)
         } else {
             hasCacheHit = false
-        }
-
-        // If not a cache hit, mark command as executed
-        if !hasCacheHit {
-            await commandCache.insert(action, forKey: cacheKey)
         }
 
         // Log the action
@@ -68,6 +68,16 @@ public actor ActionLogManager {
         }
 
         return hasCacheHit
+    }
+
+    /// Mark an action as executed so identical follow-up commands are deduplicated for the cache's
+    /// lifetime.
+    ///
+    /// Must only be called once the command actually reached the device — see `log(action:)`.
+    ///
+    /// - Parameter action: The action that was successfully performed.
+    public func markExecuted(_ action: HomeManagableAction) async {
+        await commandCache.insert(action, forKey: CommandCacheKey(action))
     }
 
     /// Reset cached commands for `item.entityId` that the freshly observed device state contradicts.

--- a/Sources/HAModels/HomeManagable.swift
+++ b/Sources/HAModels/HomeManagable.swift
@@ -21,7 +21,10 @@ public protocol HomeManagable: EntityValidator, Sendable {
     func getCurrentEntity(with entityId: EntityId) async throws -> EntityStorageItem
     func getPreviousEntity(with entityId: EntityId) async throws -> EntityStorageItem?
     func getAllEntitiesLive() async throws -> [EntityStorageItem]
-    func addEntityHistory(_ item: EntityStorageItem) async
+    /// - Returns: Whether the item carries new information, i.e. differs in value — not just in
+    ///   timestamp — from the last known state of that entity.
+    @discardableResult
+    func addEntityHistory(_ item: EntityStorageItem) async -> Bool
 
     func perform(_ action: HomeManagableAction) async
     func trigger(scene sceneName: String) async

--- a/Sources/Server/Jobs/EventProcessingJob.swift
+++ b/Sources/Server/Jobs/EventProcessingJob.swift
@@ -24,7 +24,10 @@ struct HomeEventProcessingJob: Job, Log {
 
             // add item to history
             if case .change(let item) = event {
-                await homeManager.addEntityHistory(item)
+                // A value-identical replay carries no new information: the adapter re-yields its
+                // full entity state on every rescan (reconnect resync, reachability flap), and
+                // triggering on those would supersede running automations for nothing.
+                guard await homeManager.addEntityHistory(item) else { continue }
             }
 
             // perform automation

--- a/Sources/Shared/AsyncDebouncer.swift
+++ b/Sources/Shared/AsyncDebouncer.swift
@@ -1,0 +1,101 @@
+//
+//  AsyncDebouncer.swift
+//  HomeAutomationKit
+//
+//  Created by Julian Kahnert on 03.08.26.
+//
+
+/// Collapses a burst of requests into a single run of `operation` and never lets two runs overlap.
+///
+/// `schedule()` (re)starts a trailing delay, so a burst settles into exactly one run — but never
+/// later than `maxDelay` after the first request of that burst, so requests arriving faster than
+/// `delay` for minutes on end cannot starve the operation. `runNow()` skips the delay for requests
+/// that must not be deferred, but is still serialized against a run in flight. Requests arriving
+/// while `operation` runs are not dropped: however many arrive, they produce exactly one follow-up
+/// run.
+///
+/// The operation runs in a task the debouncer never cancels, so requests and cancellation can only
+/// ever affect a run that has not started yet.
+public actor AsyncDebouncer {
+    private let delay: Duration
+    private let maxDelay: Duration
+    private let operation: @Sendable () async -> Void
+
+    private var delayTask: Task<Void, Never>?
+    private var runTask: Task<Void, Never>?
+    /// When the requests coalesced so far have to run at the latest — set by the first request of a
+    /// burst, not extended by the ones following it.
+    private var runBy: ContinuousClock.Instant?
+    /// Set while a run is in flight to remember that its result is already stale.
+    private var isDirty = false
+
+    public init(delay: Duration = .seconds(5), maxDelay: Duration = .seconds(30), operation: @escaping @Sendable () async -> Void) {
+        self.delay = delay
+        self.maxDelay = maxDelay
+        self.operation = operation
+    }
+
+    /// Request a run once `delay` has passed without a further request, at the latest `maxDelay`
+    /// after the first request of the current burst.
+    public func schedule() {
+        let now = ContinuousClock.now
+        let deadline = runBy ?? now.advanced(by: maxDelay)
+        runBy = deadline
+        let wait = min(delay, now.duration(to: deadline))
+
+        delayTask?.cancel()
+        delayTask = Task {
+            do {
+                try await Task.sleep(for: max(.zero, wait))
+            } catch {
+                // superseded by a later request, or the pending run was cancelled
+                return
+            }
+            guard !Task.isCancelled else { return }
+
+            // Drop this handle before handing the request to the runner: from here on the debouncer
+            // holds nothing it could cancel, so the operation always runs to completion.
+            delayTask = nil
+            runBy = nil
+            startRun()
+        }
+    }
+
+    /// Request a run without waiting for the debounce delay, absorbing a pending trailing run.
+    ///
+    /// Returns once the run this call started has finished — or immediately if a run was already in
+    /// flight, since that run will pick the request up.
+    public func runNow() async {
+        cancelPending()
+        await startRun()?.value
+    }
+
+    /// Drop a pending trailing run. A run already in flight is unaffected.
+    public func cancelPending() {
+        delayTask?.cancel()
+        delayTask = nil
+        runBy = nil
+    }
+
+    /// - Returns: The task running the operation, but only if this call started it.
+    @discardableResult
+    private func startRun() -> Task<Void, Never>? {
+        guard runTask == nil else {
+            isDirty = true
+            return nil
+        }
+
+        let task = Task { await drain() }
+        runTask = task
+        return task
+    }
+
+    private func drain() async {
+        repeat {
+            isDirty = false
+            await operation()
+        } while isDirty
+
+        runTask = nil
+    }
+}

--- a/Tests/HomeAutomationKitTests/ActionLogManagerTests.swift
+++ b/Tests/HomeAutomationKitTests/ActionLogManagerTests.swift
@@ -20,7 +20,8 @@ struct ActionLogManagerTests {
         let manager = ActionLogManager()
         let action = HomeManagableAction.turnOn(switchId)
 
-        #expect(await manager.log(action: action) == false) // first call: miss → cached
+        #expect(await manager.log(action: action) == false) // first call: miss
+        await manager.markExecuted(action) // command reached the device → cached
 
         let echo = EntityStorageItem(entityId: switchId, isDeviceOn: true)
         let invalidated = await manager.invalidateContradictedCommands(for: echo)
@@ -35,6 +36,7 @@ struct ActionLogManagerTests {
         let action = HomeManagableAction.turnOn(switchId)
 
         #expect(await manager.log(action: action) == false)
+        await manager.markExecuted(action)
 
         let drift = EntityStorageItem(entityId: switchId, isDeviceOn: false)
         let invalidated = await manager.invalidateContradictedCommands(for: drift)
@@ -49,6 +51,7 @@ struct ActionLogManagerTests {
         let action = HomeManagableAction.setBrightness(brightnessId, 0.5)
 
         #expect(await manager.log(action: action) == false)
+        await manager.markExecuted(action)
 
         // echo of the commanded value (50%) confirms → kept
         let echo = EntityStorageItem(entityId: brightnessId, brightness: 50)
@@ -59,6 +62,30 @@ struct ActionLogManagerTests {
         let drift = EntityStorageItem(entityId: brightnessId, brightness: 10)
         #expect(await manager.invalidateContradictedCommands(for: drift) == [action])
         #expect(await manager.log(action: action) == false)
+    }
+
+    @Test("A logged but unexecuted command stays a cache miss")
+    func unexecutedCommandIsNotDeduped() async {
+        let manager = ActionLogManager()
+        let action = HomeManagableAction.turnOn(switchId)
+
+        // The command never reached the device (cancelled, adapter error) — the next attempt must
+        // get through.
+        #expect(await manager.log(action: action) == false)
+        #expect(await manager.log(action: action) == false)
+    }
+
+    @Test("markExecuted makes an identical command a cache hit")
+    func executedCommandIsDeduped() async {
+        let manager = ActionLogManager()
+        let action = HomeManagableAction.setBrightness(brightnessId, 0.5)
+
+        #expect(await manager.log(action: action) == false)
+        await manager.markExecuted(action)
+
+        #expect(await manager.log(action: action) == true)
+        // a different value for the same entity + action kind is not a duplicate
+        #expect(await manager.log(action: .setBrightness(brightnessId, 0.8)) == false)
     }
 
     @Test("State change for an entity with no cached command is a no-op")
@@ -75,7 +102,9 @@ struct ActionLogManagerTests {
         let brightnessAction = HomeManagableAction.setBrightness(switchId, 0.5)
 
         #expect(await manager.log(action: onAction) == false)
+        await manager.markExecuted(onAction)
         #expect(await manager.log(action: brightnessAction) == false)
+        await manager.markExecuted(brightnessAction)
 
         // Only the power state drifted (off); brightness is unknown in this update.
         let drift = EntityStorageItem(entityId: switchId, isDeviceOn: false)
@@ -97,6 +126,7 @@ struct ActionLogManagerTests {
         let action = HomeManagableAction.turnOn(switchId)
 
         #expect(await manager.log(action: action) == false)
+        await manager.markExecuted(action)
 
         // Advance past the 2-minute TTL so the cache entry expires.
         holder.currentDate = holder.currentDate.addingTimeInterval(121)

--- a/Tests/HomeAutomationKitTests/HomeManagerTests.swift
+++ b/Tests/HomeAutomationKitTests/HomeManagerTests.swift
@@ -1,0 +1,218 @@
+//
+//  HomeManagerTests.swift
+//  HomeAutomationKit
+//
+//  Created by Julian Kahnert on 03.08.26.
+//
+
+import Distributed
+import Foundation
+import HAApplicationLayer
+import HAModels
+import Testing
+
+private enum FakeAdapterError: Error {
+    case unreachable
+}
+
+/// Observes what the adapter was asked to do and controls how it responds.
+private actor AdapterProbe {
+    private(set) var startedPerforms = 0
+    private(set) var completedPerforms = 0
+    private(set) var performedActions: [HomeManagableAction] = []
+
+    private let failure: FakeAdapterError?
+    private let performDuration: Duration?
+
+    init(failure: FakeAdapterError? = nil, performDuration: Duration? = nil) {
+        self.failure = failure
+        self.performDuration = performDuration
+    }
+
+    /// Records every attempt, including the failing ones.
+    func perform(_ action: HomeManagableAction) async throws {
+        startedPerforms += 1
+        performedActions.append(action)
+
+        if let performDuration {
+            // Deliberately not `try?`: if cancellation reached the shielded command, the sleep
+            // throws and the command is recorded as not completed.
+            try await Task.sleep(for: performDuration)
+        }
+
+        if let failure { throw failure }
+
+        completedPerforms += 1
+    }
+
+    func waitForStart() async {
+        while startedPerforms == 0 {
+            await Task.yield()
+        }
+    }
+
+    func waitForPerforms(_ count: Int, timeout: Duration = .seconds(1)) async {
+        let deadline = ContinuousClock.now + timeout
+        while startedPerforms < count, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}
+
+/// `MockHomeAdapter` is a `HomeManagable`, not an `EntityAdapterable`, so `HomeManager` needs its own
+/// adapter double: a distributed actor on the local testing actor system.
+private distributed actor FakeEntityAdapter: EntityAdapterable {
+    typealias ActorSystem = LocalTestingDistributedActorSystem
+
+    private let probe: AdapterProbe
+
+    init(actorSystem: ActorSystem, probe: AdapterProbe) {
+        self.actorSystem = actorSystem
+        self.probe = probe
+    }
+
+    distributed func getAllEntitiesLive() async -> [EntityStorageItem] {
+        []
+    }
+
+    distributed func findEntity(_ entity: EntityId) async throws {}
+
+    distributed func perform(_ action: HomeManagableAction) async throws {
+        try await probe.perform(action)
+    }
+
+    distributed func trigger(scene sceneName: String) async throws {}
+}
+
+struct HomeManagerTests {
+
+    private let switchId = EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .switcher)
+
+    /// - Parameter retryTicks: Defaults to a stream that finishes right away, so retries only happen
+    ///   in the tests that drive them.
+    private func makeHomeManager(probe: AdapterProbe, retryTicks: AsyncStream<Void> = AsyncStream { _ in }) async -> HomeManager {
+        let adapter = FakeEntityAdapter(actorSystem: LocalTestingDistributedActorSystem(), probe: probe)
+        return await HomeManager(getAdapter: { adapter },
+                                 storageRepo: MockStorageRepository(),
+                                 notificationSender: MockNotificationSender(),
+                                 location: Location(latitude: 0, longitude: 0),
+                                 actionLogManager: ActionLogManager(),
+                                 retryTicks: retryTicks)
+    }
+
+    // MARK: - command deduplication
+
+    @Test("An executed command deduplicates an identical follow-up")
+    func executedCommandIsDeduplicated() async {
+        let probe = AdapterProbe()
+        let homeManager = await makeHomeManager(probe: probe)
+
+        await homeManager.perform(.turnOn(switchId))
+        await homeManager.perform(.turnOn(switchId))
+
+        #expect(await probe.startedPerforms == 1)
+    }
+
+    @Test("A failed command does not poison the dedup cache")
+    func failedCommandIsNotDeduplicated() async {
+        let probe = AdapterProbe(failure: .unreachable)
+        let homeManager = await makeHomeManager(probe: probe)
+
+        await homeManager.perform(.turnOn(switchId))
+        await homeManager.perform(.turnOn(switchId))
+
+        #expect(await probe.startedPerforms == 2)
+    }
+
+    // MARK: - cancellation
+
+    @Test("A cancelled run issues no further commands")
+    func cancelledRunIssuesNoCommand() async {
+        let probe = AdapterProbe()
+        let homeManager = await makeHomeManager(probe: probe)
+
+        let run = Task {
+            // returns immediately once the task is cancelled
+            try? await Task.sleep(for: .seconds(10))
+            await homeManager.perform(.turnOn(switchId))
+        }
+        run.cancel()
+        await run.value
+
+        #expect(await probe.startedPerforms == 0)
+        #expect(await homeManager.getActionLog(limit: nil).isEmpty)
+    }
+
+    @Test("Cancelling a run does not abort a command that already started")
+    func startedCommandSurvivesCancellation() async {
+        let probe = AdapterProbe(performDuration: .milliseconds(100))
+        let homeManager = await makeHomeManager(probe: probe)
+
+        let run = Task { await homeManager.perform(.turnOn(switchId)) }
+        await probe.waitForStart()
+        run.cancel()
+        await run.value
+
+        #expect(await probe.completedPerforms == 1)
+
+        // the command counts as executed, so an identical one is still deduplicated
+        await homeManager.perform(.turnOn(switchId))
+        #expect(await probe.startedPerforms == 1)
+    }
+
+    // MARK: - retries
+
+    @Test("A failing command is retried twice and then dropped")
+    func failingCommandIsDroppedAfterThreeAttempts() async {
+        let (ticks, tickContinuation) = AsyncStream<Void>.makeStream(of: Void.self)
+        let probe = AdapterProbe(failure: .unreachable)
+        let homeManager = await makeHomeManager(probe: probe, retryTicks: ticks)
+
+        await homeManager.perform(.turnOn(switchId))
+        #expect(await probe.startedPerforms == 1)
+
+        // the retry loop consumes the ticks serially, so the attempts are ordered
+        for _ in 0..<5 {
+            tickContinuation.yield(())
+        }
+        await probe.waitForPerforms(3)
+
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(await probe.startedPerforms == 3)
+    }
+
+    @Test("Failed commands for different characteristics of one device are retried independently")
+    func retriesAreKeyedPerCharacteristic() async {
+        let brightnessId = EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .brightness)
+        let colorTemperatureId = EntityId(placeId: "room", name: "light", characteristicsName: nil, characteristic: .colorTemperature)
+        let (ticks, tickContinuation) = AsyncStream<Void>.makeStream(of: Void.self)
+        let probe = AdapterProbe(failure: .unreachable)
+        let homeManager = await makeHomeManager(probe: probe, retryTicks: ticks)
+
+        // the characteristic is part of the EntityId, so these occupy separate retry slots
+        await homeManager.perform(.setBrightness(brightnessId, 0.4))
+        await homeManager.perform(.setColorTemperature(colorTemperatureId, 0.6))
+        #expect(await probe.startedPerforms == 2)
+
+        tickContinuation.yield(())
+        await probe.waitForPerforms(4)
+        #expect(await probe.startedPerforms == 4)
+    }
+
+    @Test("Only the newest failed command of an entity is replayed")
+    func newestFailedCommandWins() async {
+        let (ticks, tickContinuation) = AsyncStream<Void>.makeStream(of: Void.self)
+        let probe = AdapterProbe(failure: .unreachable)
+        let homeManager = await makeHomeManager(probe: probe, retryTicks: ticks)
+
+        // both target the same switcher entity, so replaying both would be contradictory
+        await homeManager.perform(.turnOn(switchId))
+        await homeManager.perform(.turnOff(switchId))
+
+        tickContinuation.yield(())
+        await probe.waitForPerforms(3)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(await probe.performedActions == [.turnOn(switchId), .turnOff(switchId), .turnOff(switchId)])
+    }
+}

--- a/Tests/HomeAutomationKitTests/HomeManagerTests.swift
+++ b/Tests/HomeAutomationKitTests/HomeManagerTests.swift
@@ -215,4 +215,30 @@ struct HomeManagerTests {
 
         #expect(await probe.performedActions == [.turnOn(switchId), .turnOff(switchId), .turnOff(switchId)])
     }
+
+    // MARK: - entity history
+
+    @Test("An unknown entity always counts as a change")
+    func unknownEntityCountsAsChange() async {
+        let homeManager = await makeHomeManager(probe: AdapterProbe())
+
+        #expect(await homeManager.addEntityHistory(EntityStorageItem(entityId: switchId, isDeviceOn: true)))
+    }
+
+    @Test("A replay that only differs in timestamp is not a change")
+    func replayIsNotAChange() async {
+        let homeManager = await makeHomeManager(probe: AdapterProbe())
+        let timestamp = Date()
+
+        #expect(await homeManager.addEntityHistory(EntityStorageItem(entityId: switchId, timestamp: timestamp, isDeviceOn: true)))
+        #expect(await homeManager.addEntityHistory(EntityStorageItem(entityId: switchId, timestamp: timestamp.addingTimeInterval(30), isDeviceOn: true)) == false)
+    }
+
+    @Test("A new value is a change")
+    func newValueIsAChange() async {
+        let homeManager = await makeHomeManager(probe: AdapterProbe())
+
+        #expect(await homeManager.addEntityHistory(EntityStorageItem(entityId: switchId, isDeviceOn: true)))
+        #expect(await homeManager.addEntityHistory(EntityStorageItem(entityId: switchId, isDeviceOn: false)))
+    }
 }

--- a/Tests/HomeAutomationKitTests/MockHomeAdapter.swift
+++ b/Tests/HomeAutomationKitTests/MockHomeAdapter.swift
@@ -120,8 +120,18 @@ final class MockHomeAdapter: @unchecked Sendable, HomeManagable {
         return storageItems
     }
 
-    func addEntityHistory(_ item: EntityStorageItem) async {
+    @discardableResult
+    func addEntityHistory(_ item: EntityStorageItem) async -> Bool {
+        let didChange: Bool
+        if var knownItem = storageItems.last(where: { $0.entityId == item.entityId }) {
+            knownItem.timestamp = item.timestamp
+            didChange = knownItem != item
+        } else {
+            didChange = true
+        }
+
         storageItems.append(item)
+        return didChange
     }
 
     func maintenance() async throws {

--- a/Tests/SharedTests/AsyncDebouncerTests.swift
+++ b/Tests/SharedTests/AsyncDebouncerTests.swift
@@ -1,0 +1,182 @@
+//
+//  AsyncDebouncerTests.swift
+//  HomeAutomationKit
+//
+//  Created by Julian Kahnert on 03.08.26.
+//
+
+import Foundation
+@testable import Shared
+import Testing
+
+/// Records how often the debounced operation ran, whether two runs ever overlapped and whether a run
+/// was cancelled while in flight.
+private actor RunRecorder {
+    private(set) var runs = 0
+    private(set) var maxConcurrentRuns = 0
+    private(set) var startedRuns = 0
+    private(set) var wasCancelled = false
+    private var activeRuns = 0
+
+    private let runDuration: Duration?
+
+    init(runDuration: Duration? = nil) {
+        self.runDuration = runDuration
+    }
+
+    func run() async {
+        startedRuns += 1
+        activeRuns += 1
+        maxConcurrentRuns = max(maxConcurrentRuns, activeRuns)
+
+        if let runDuration {
+            do {
+                // deliberately not `try?` — that would swallow the cancellation signal
+                try await Task.sleep(for: runDuration)
+            } catch {
+                wasCancelled = true
+            }
+        }
+        if Task.isCancelled {
+            wasCancelled = true
+        }
+
+        activeRuns -= 1
+        runs += 1
+    }
+
+    func waitForStart(timeout: Duration = .seconds(1)) async {
+        let deadline = ContinuousClock.now + timeout
+        while startedRuns == 0, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+    }
+}
+
+struct AsyncDebouncerTests {
+
+    @Test("A burst results in exactly one trailing run")
+    func burstCollapsesIntoOneRun() async {
+        let recorder = RunRecorder()
+        let debouncer = AsyncDebouncer(delay: .milliseconds(50)) { await recorder.run() }
+
+        for _ in 0..<10 {
+            await debouncer.schedule()
+        }
+
+        #expect(await recorder.runs == 0) // nothing ran yet — the delay is still trailing
+
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(await recorder.runs == 1)
+        #expect(await recorder.maxConcurrentRuns == 1)
+    }
+
+    @Test("Requests during a run produce exactly one follow-up run")
+    func requestsDuringRunCoalesceIntoOneFollowUp() async {
+        let recorder = RunRecorder(runDuration: .milliseconds(100))
+        let debouncer = AsyncDebouncer(delay: .milliseconds(10)) { await recorder.run() }
+
+        let firstRun = Task { await debouncer.runNow() }
+        await recorder.waitForStart()
+
+        for _ in 0..<5 {
+            await debouncer.runNow()
+        }
+        await firstRun.value
+
+        // the first run plus a single follow-up covering all 5 requests
+        #expect(await recorder.runs == 2)
+        #expect(await recorder.maxConcurrentRuns == 1)
+    }
+
+    @Test("A pending trailing run is absorbed by a run in flight")
+    func pendingRunIsAbsorbed() async {
+        let recorder = RunRecorder(runDuration: .milliseconds(100))
+        let debouncer = AsyncDebouncer(delay: .milliseconds(10)) { await recorder.run() }
+
+        let firstRun = Task { await debouncer.runNow() }
+        await recorder.waitForStart()
+
+        await debouncer.schedule()
+        await firstRun.value
+
+        // the scheduled run fires while the first one is still in flight
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(await recorder.runs == 2)
+        #expect(await recorder.maxConcurrentRuns == 1)
+    }
+
+    @Test("The immediate path skips the delay")
+    func immediateRunSkipsDelay() async {
+        let recorder = RunRecorder()
+        let debouncer = AsyncDebouncer(delay: .seconds(60)) { await recorder.run() }
+
+        let start = ContinuousClock.now
+        await debouncer.runNow()
+        let duration = start.duration(to: .now)
+
+        #expect(await recorder.runs == 1)
+        #expect(duration < .seconds(1))
+    }
+
+    @Test("The immediate path absorbs a pending trailing run")
+    func immediateRunAbsorbsPendingRun() async {
+        let recorder = RunRecorder()
+        let debouncer = AsyncDebouncer(delay: .milliseconds(50)) { await recorder.run() }
+
+        await debouncer.schedule()
+        await debouncer.runNow()
+
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(await recorder.runs == 1)
+    }
+
+    @Test("Cancelling drops a pending trailing run")
+    func cancelPendingDropsScheduledRun() async {
+        let recorder = RunRecorder()
+        let debouncer = AsyncDebouncer(delay: .milliseconds(50)) { await recorder.run() }
+
+        await debouncer.schedule()
+        await debouncer.cancelPending()
+
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(await recorder.runs == 0)
+    }
+
+    @Test("Requests arriving faster than the delay still run within maxDelay")
+    func maxDelayCapsAContinuousBurst() async {
+        let recorder = RunRecorder()
+        let debouncer = AsyncDebouncer(delay: .milliseconds(100), maxDelay: .milliseconds(300)) { await recorder.run() }
+
+        // requests keep arriving faster than the debounce delay for well beyond maxDelay
+        let start = ContinuousClock.now
+        while start.duration(to: .now) < .milliseconds(700) {
+            await debouncer.schedule()
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+
+        // the cap forced a run while the requests were still coming in
+        #expect(await recorder.startedRuns >= 1)
+        #expect(await recorder.wasCancelled == false)
+    }
+
+    @Test("A run in flight is never cancelled by the debouncer")
+    func runInFlightIsNotCancelled() async {
+        let recorder = RunRecorder(runDuration: .milliseconds(100))
+        let debouncer = AsyncDebouncer(delay: .milliseconds(20)) { await recorder.run() }
+
+        // started via the debounced path, so a delay task hands the run over
+        await debouncer.schedule()
+        await recorder.waitForStart()
+
+        // none of these may touch the operation that is already running
+        await debouncer.schedule()
+        await debouncer.runNow()
+        await debouncer.cancelPending()
+
+        try? await Task.sleep(for: .milliseconds(500))
+        #expect(await recorder.wasCancelled == false)
+        #expect(await recorder.maxConcurrentRuns == 1)
+        #expect(await recorder.runs == 2) // the first run plus one follow-up for the later requests
+    }
+}


### PR DESCRIPTION
## Problem

Recurring evening incidents (2026-07-28, 2026-07-31, 2026-08-02): automations run but leave lights **half-configured** — switched on with wrong brightness/color temperature, or not switched at all — while every health surface stays green. Server log signature: actions failing with `CancellationError()` (not a HomeKit error), the same automation re-running 4× within 2 seconds.

Root cause chain (confirmed against adapter + server logs):

1. A HomeKit accessory flaps reachability (292 events on 2026-08-02, 252 in one burst).
2. **Every** delegate callback — including `accessoryDidUpdateReachability` — runs a full home rescan (333× that day), concurrently and uncoalesced (#190 F12).
3. Each rescan re-yields **every** subscribed entity into the event stream, value-unchanged.
4. Each replay re-triggers automations; `AutomationService` cancels the still-running previous run of the same automation (#190 F20).
5. Cancellation kills the in-flight HomeKit command mid-flight, leaving the device half-configured (#190 F38).
6. The command dedup cache was populated **before** execution, so the cancelled command poisons it for 2 minutes: the replacement run and the 5s retry loop are both skipped as "duplicate" — the retry mechanism was structurally dead code (#190 F3).

## Fix (layered — each layer alone reduces the blast radius, together they close it)

**Server:**
- **S1** `ActionLogManager`: commands enter the dedup cache only via new `markExecuted(_:)`, called after the adapter call succeeds. A cancelled/failed command stays a cache miss, so replacement runs and retries actually execute. (F3)
- **S2** `HomeManager.perform`: cancellation is honoured at command boundaries only — an entry guard stops superseded runs from issuing further commands (also neutralizes the `try?`-swallowed cancellation in `MotionAtNight`), and an unstructured-task shield lets a started command always run to completion (the remote call has its own 30s timeout). "Half-set by an aborted single command" is no longer possible. (F38)
- **S3** Ingress dedup: `addEntityHistory` now reports whether the state actually changed (timestamp-aligned comparison); `HomeEventProcessingJob` only triggers automations for genuine changes. Rescan floods still refresh history/drift-invalidation but no longer reach the automation engine. Also stops replay floods from resetting `WindowOpen`'s 15-minute notification timer indefinitely. (F20)
- **S4** Retry hardening: failed actions are retried up to 3 attempts, then dropped with a `critical` log (→ push notification) instead of being silently discarded after one retry. Keying stays per `EntityId` (which already separates characteristics, so brightness/color-temperature retries of the same lamp coexist; contradictory `turnOn`/`turnOff` share the switcher slot so the newest intent wins).

**Adapter** (requires rebuilding the FlowKit Adapter app):
- **A1** Rescans are debounced (5s trailing, 30s max-wait so a sustained flap cannot starve the rescan indefinitely) and single-flighted with a dirty flag (new `AsyncDebouncer` in `Shared`). A 252-flap burst now causes one rescan instead of 252. The reconnect resync (`pushFullState`) bypasses the delay but shares the single-flight, so full-snapshot resync semantics are preserved — deduplication happens server-side (S3), never by dropping adapter yields (lossy-link safety). (F12)
- **A2** The release-reachable `fatalError` on a transient nil accessory back-reference in `updateEntities()` is now log-and-skip. (F9)
- **A3** `HomeKitAdapter.perform()` throws when the target characteristic/home/scene cannot be resolved instead of silently reporting success — otherwise S1 would re-poison the cache in exactly the 6h-reset window where this occurs. (F4)

## What deliberately did NOT change

- `AutomationService`'s cancel-on-retrigger: `MotionAtNight`'s off-countdown restart *requires* it (the timer's entire state is the task's lifetime). The fix removes the *spurious* cancellations (S3) and makes the remaining, legitimate ones safe (S1+S2).
- Full-rescan semantics: rescans still re-yield everything — that is the reconnect resync mechanism. Only their *frequency* (A1) and their *effect on automations* (S3) changed.

## Behavior notes

- A manual "Stop Automation" during `MotionAtNight`'s final turn-off group now leaves the remaining lights on (entry guard) — acceptable "stop now" semantics; a re-trigger supersede is unaffected (the replacement run issues its own turn-off).
- Newly added accessories get their notification subscription up to ~5s later (debounce).
- Ingress dedup only collapses discrete/boolean values (motion, contact, switch state) — exactly the incident path; analog values (lux) are never bit-identical.
- Invariant documented in code: no `.change`-triggered automation may command its own trigger entity (holds today; a violation would break drift-reissue).
- Accepted residuals found by review: (a) a state echo arriving in the milliseconds between adapter completion and `markExecuted` can leave a cache entry that the echo would have invalidated — self-heals on the next echo for that entity, TTL-bounded at 2 min; (b) a value-identical replay can no longer accidentally re-arm an automation whose previous run ended abnormally — re-arming now requires a genuine state transition; (c) should an accessory ever send genuine same-value re-notifications (HomeKit notifies on change, none observed), they no longer restart `MotionAtNight`'s countdown.

## Tests

`swift test`: 139 tests in 24 suites (baseline 122/22). New: ActionLogManager mark-after-success semantics, `HomeManagerTests` (9 tests: dedup-after-success, failure→cache-miss→retry, cancelled-context guard, in-flight shield, per-action-kind retry keying, 3-attempts-then-give-up via injected tick stream, `addEntityHistory` change detection ×3), `AsyncDebouncerTests` (6 tests: burst coalescing, single-flight, dirty-flag rerun, immediate path). Adapter target compile-verified via the CI invocation (`xcodebuild … FlowKit Adapter … BUILD SUCCEEDED`; plain `swift build` cannot compile `Sources/Adapter` — `canImport(HomeKit)` is false on native macOS).

## Relation to #190 and follow-ups

Addresses #190 findings F3, F4, F9, F12, F20, F38. A full re-verification of all 40 findings against current develop (post-StarActorSystem) plus a fresh review of the new connection layer surfaced these **confirmed, still-open** items — deliberately out of scope here (link-layer, not the incident chain):

- Server can drop the adapter's hello frame in a startup race (async `onBinary` handlers installed late; server never times out an attached-but-never-up connection) — plausible mechanism for the known "daily 23:00 restart wedges the link" incident.
- Adapter has no link-liveness deadline: it can stay `.up` on a dead socket until the next outbound call times out (30s each, serial event pump stalls behind it).
- Entity events produced while the link is down are still dropped, not buffered (F6-transformed; blast radius reduced by the existing reconnect full-resync).
- F5/F23 (6h reset publishes empty homes list; `Timer.publish` first-tick alignment), F13/F14 (delegate-path readValue drop / out-of-order events), F2/F18 (config + toggle persistence), F16 (APNS token deletion on transient errors), F17 (unindexed history queries).

Why the accessories flap in the first place (radio/bridge/firmware) remains uninvestigated — outside this codebase.
